### PR TITLE
Workaround for iOS 15 texture memory issue

### DIFF
--- a/source/client/applications/ExplorerApplication.ts
+++ b/source/client/applications/ExplorerApplication.ts
@@ -185,6 +185,13 @@ Version: ${ENV_VERSION}
             }	
         }*/
 
+        // Temporary hack to work around iOS 15+ texture memory issue
+        const IS_IOS = /^(iPad|iPhone|iPod)/.test(window.navigator.platform) ||
+            (/^Mac/.test(window.navigator.platform) && window.navigator.maxTouchPoints > 1);
+        if (IS_IOS) {
+            window.createImageBitmap = undefined;
+        }
+
         // start rendering
         engine.pulse.start();
     }


### PR DESCRIPTION
https://discourse.threejs.org/t/textures-in-gltf-sometimes-display-black-but-only-on-ios/30520/29