### PR TITLE
update articles and annotations languages when UI lang is not the default

### DIFF
--- a/source/client/components/CVAnnotationView.ts
+++ b/source/client/components/CVAnnotationView.ts
@@ -388,7 +388,11 @@ export default class CVAnnotationView extends CObject3D
 
     fromData(data: IAnnotation[])
     {
-        data.forEach(annotationJson => this.addAnnotation(new Annotation(annotationJson)));
+        data.forEach(annotationJson => {
+            let annotation = new Annotation(annotationJson);
+            annotation.language = this.language.outs.language.value;
+            this.addAnnotation(annotation);
+        });
         this.emit<ITagUpdateEvent>({ type: "tag-update" });
     }
 

--- a/source/client/components/CVReader.ts
+++ b/source/client/components/CVReader.ts
@@ -98,7 +98,7 @@ export default class CVReader extends Component
         return this.getMainComponent(CVAnalytics);
     }
     protected get language() {
-        return this.getGraphComponent(CVLanguageManager);
+        return this.getGraphComponent(CVLanguageManager, true);
     }
 
     protected _articles: Dictionary<IArticleEntry>;
@@ -198,6 +198,7 @@ export default class CVReader extends Component
         if (event.remove) {
             event.object.outs.language.off("value", this.updateLanguage, this);
         }
+        this.updateArticles();
     }
 
     protected updateArticles()
@@ -213,6 +214,7 @@ export default class CVReader extends Component
                 masterList[article.id] = { article, node };
             });
         });
+        if(this.language) this.updateLanguage();
     }
 
     protected updateLanguage()


### PR DESCRIPTION
when UI locale is not the default value, all articles titles are undefined.

The source is that `CVReader.onLanguageComponent()` was called once, before the articles are loaded (maybe it's a race condition and doesn't happen every time, didn't investigate).

My change does two things : 
- set `CVReader.language` to not throw an error if `CVLanguageManager` doesn't exist yet. I belive it is the intended behavior as it's generally discouraged to have properties getters throw errors and I couldn't find anywhere it was supposed to.
- call `CVReader.updateArticles()` if the language manager is ever loaded before the meta component. Prevents an hypothetical race condition
- if articles are updated and the language is loaded, set the language using `CVReader.updateLanguage()`

I made the minimal viable change but there is more to do on this subject. I'll make more pull requests when I can.
