### PR TITLE
Add a dialog to define new model derivatives

### DIFF
--- a/source/client/applications/StoryApplication.ts
+++ b/source/client/applications/StoryApplication.ts
@@ -42,6 +42,7 @@ import NVoyagerStory from "../nodes/NVoyagerStory";
 import MainView from "../ui/story/MainView";
 import CVTaskProvider, { ETaskMode } from "../components/CVTaskProvider";
 import CVStandaloneFileManager from "client/components/CVStandaloneFileManager";
+import CVModelEditor from "client/components/CVModelEditor";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -189,6 +190,8 @@ export default class StoryApplication
             props.dragdrop = true;
             app.createComponent(CVStandaloneFileManager);
         }
+
+        app.createComponent(CVModelEditor);
 
         this.mediaManager.rootUrl = this.assetManager.baseUrl;
 

--- a/source/client/applications/StoryApplication.ts
+++ b/source/client/applications/StoryApplication.ts
@@ -56,6 +56,8 @@ export interface IStoryApplicationProps extends IExplorerApplicationProps
     mode?: string;
     /** When set to true, application displays additional expert level tools. */
     expert?: boolean;
+    /** When set to true, application supports dragging and dropping files. */
+    dragdrop?: boolean;
 }
 
 /**
@@ -153,6 +155,7 @@ export default class StoryApplication
         props.referrer = props.referrer || parseUrlParameter("referrer");
         props.mode = props.mode || parseUrlParameter("mode") || "prep";
         props.expert = props.expert !== undefined ? props.expert : parseUrlParameter("expert") !== "false";
+        props.dragdrop = props.dragdrop || false; 
 
         // If in standalone mode, remove root and document params that may be present
         const modeText = props.mode.toLowerCase();
@@ -183,10 +186,16 @@ export default class StoryApplication
         }
         else if (modeText.startsWith("stand")) {
             mode = ETaskMode.Standalone;
+            props.dragdrop = true;
             app.createComponent(CVStandaloneFileManager);
         }
 
         this.mediaManager.rootUrl = this.assetManager.baseUrl;
+
+        // if dragging/dropping have to assume that a non-loading url is still valid
+        if(props.dragdrop === true) {
+            this.assetManager.ins.baseUrlValid.setValue(true);
+        }
 
         const tasks = this.system.getMainComponent(CVTaskProvider);
         tasks.ins.mode.setValue(mode);

--- a/source/client/applications/storyTypes.ts
+++ b/source/client/applications/storyTypes.ts
@@ -33,6 +33,7 @@ import CVAudioTask from "../components/CVAudioTask";
 
 import NVVoyagerStory from "../nodes/NVoyagerStory";
 import NVTasks from "../nodes/NVTasks";
+import CVModelEditor from "client/components/CVModelEditor";
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -42,6 +43,7 @@ const types = [
     CVAssetWriter,
     CVMediaManager,
     CVStandaloneFileManager,
+    CVModelEditor,
 
     CVTaskProvider,
     CVSettingsTask,

--- a/source/client/components/CVMediaManager.ts
+++ b/source/client/components/CVMediaManager.ts
@@ -181,6 +181,17 @@ export default class CVMediaManager extends CAssetManager
         }).catch(e => {});
     }
 
+    uploadFiles(files: FileList, folder: IAssetEntry): Promise<any>
+    {
+        const standaloneManager = this.standaloneFileManager;
+        if(standaloneManager) {
+            ; // TODO - considering removing this support
+        }
+        else {
+            return super.uploadFiles(files, folder);
+        }
+    }
+
     refresh()
     {
         const standaloneManager = this.standaloneFileManager;

--- a/source/client/components/CVMediaManager.ts
+++ b/source/client/components/CVMediaManager.ts
@@ -93,6 +93,18 @@ export default class CVMediaManager extends CAssetManager
         }
     }
 
+    ingestFiles(files: Map<string, File>)
+    {
+        if(this.standaloneFileManager) {
+            this.standaloneFileManager.onFileDrop(files);
+        }
+        else {
+            const fileList = new DataTransfer();
+            files.forEach(file => fileList.items.add(file));
+            this.uploadFiles(fileList.files, this.root);
+        }
+    }
+
     refresh()
     {
         const standaloneManager = this.standaloneFileManager;

--- a/source/client/components/CVMediaManager.ts
+++ b/source/client/components/CVMediaManager.ts
@@ -1,6 +1,6 @@
 /**
  * 3D Foundation Project
- * Copyright 2019 Smithsonian Institution
+ * Copyright 2023 Smithsonian Institution
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,13 @@ import Notification from "@ff/ui/Notification";
 import CVStandaloneFileManager from "./CVStandaloneFileManager";
 import CVAssetManager from "./CVAssetManager";
 import resolvePathname from "resolve-pathname";
+import ExplorerApplication from "client/applications/ExplorerApplication";
+import MainView from "client/ui/story/MainView";
+import CVDocumentProvider from "./CVDocumentProvider";
+import ImportMenu from "client/ui/story/ImportMenu";
+import CVModel2 from "./CVModel2";
+import { EDerivativeUsage } from "client/schema/model";
+import CSelection from "client/../../libs/ff-graph/source/components/CSelection";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -80,10 +87,11 @@ export default class CVMediaManager extends CAssetManager
     uploadFile(name: string, blob: Blob, folder: IAssetEntry): Promise<any>
     {
         const filename = decodeURI(name);
-        const url = resolvePathname(folder.info.path + filename, this.rootUrl);
+        const filepath = folder.info.path.length > 1 ? folder.info.path + filename : filename;
+        const url = resolvePathname(filepath, this.rootUrl);
         
         if(this.standaloneFileManager) {
-            this.standaloneFileManager.addFile(CVMediaManager.articleFolder + "/" + filename, [blob]);
+            this.standaloneFileManager.addFile(filepath, [blob]);
             this.refresh();
             return Promise.resolve();
         }
@@ -95,14 +103,82 @@ export default class CVMediaManager extends CAssetManager
 
     ingestFiles(files: Map<string, File>)
     {
-        if(this.standaloneFileManager) {
-            this.standaloneFileManager.onFileDrop(files);
+        // If a scene file has been dropped, push to end
+        const fileArray = Array.from(files);
+        const docIndex = fileArray.findIndex( (element) => { return element[0].toLowerCase().indexOf(".svx.json") > -1 });
+        const documentProvided : boolean = docIndex > -1;
+        if(documentProvided) {
+            fileArray.push(fileArray.splice(docIndex,1)[0]);
+
+            // we have a new scene, so clear out standalone file manager
+            if(this.standaloneFileManager) {
+                this.standaloneFileManager.reload();
+            }
         }
-        else {
-            const fileList = new DataTransfer();
-            files.forEach(file => fileList.items.add(file));
-            this.uploadFiles(fileList.files, this.root);
-        }
+
+        const documentRoot = documentProvided ? fileArray[fileArray.length-1][0].replace(fileArray[fileArray.length-1][1].name, '') : "";
+
+        fileArray.forEach(([path, file]) => {
+            const cleanfileName = decodeURI(file.name);
+            const filenameLower = cleanfileName.toLowerCase();
+            
+            if (filenameLower.match(/\.(gltf|glb|bin|svx.json|html|jpg|png|usdz)$/)) {
+
+                if(!documentProvided && filenameLower.match(/\.(jpg|png)$/) && !fileArray.some(entry => entry[0].endsWith("gltf"))) {
+                    path = CVMediaManager.articleFolder + "/" + cleanfileName;
+                }
+
+                // normalize path relative to document root
+                let normalizedPath = documentProvided ? path.replace(documentRoot, '') : path;
+                normalizedPath = normalizedPath.startsWith("/") ? normalizedPath.substr(1) : normalizedPath;
+
+                if (filenameLower.match(/\.(svx.json)$/)) {
+                    const mainView : MainView = document.getElementsByTagName('voyager-story')[0] as MainView;
+                    const explorer : ExplorerApplication = mainView.app.explorerApp;
+            
+                    this.uploadFile(normalizedPath, file, this.root).then(() => {
+                        explorer.loadDocument(normalizedPath);
+                        this.getMainComponent(CVDocumentProvider).refreshDocument();
+                    }); 
+                }
+                else if (!documentProvided && filenameLower.match(/\.(gltf|glb)$/)) {
+                    this.uploadFile(normalizedPath, file, this.root).then(() => this.handleModelImport(normalizedPath));
+                }
+                else {
+                    this.uploadFile(normalizedPath, file, this.root);
+                }
+            }
+            else {
+                new Notification(`Unhandled file: '${cleanfileName}'`, "warning", 4000);
+            }
+        });
+    }
+
+    protected handleModelImport(filepath: string) {
+        const mainView : MainView = document.getElementsByTagName('voyager-story')[0] as MainView;
+        const activeDoc = this.getMainComponent(CVDocumentProvider).activeComponent;
+        const filename = filepath.substr(filepath.lastIndexOf("/") + 1);
+        const selection = this.getMainComponent(CSelection);
+
+        ImportMenu.show(mainView, activeDoc.setup.language, filename).then(([quality, parentName]) => {
+            const model = this.getSystemComponents(CVModel2).find(element => element.node.name === parentName);
+            if(model === undefined) {
+                // converting path to relative (TODO: check if all browsers will have leading slash here)
+                const newModel = activeDoc.appendModel(filepath, quality);
+                const name = parentName;
+                newModel.node.name = name;
+                newModel.ins.name.setValue(name);
+                newModel.ins.quality.setValue(quality);
+                selection.selectNode(newModel.node);
+            }
+            else {
+                model.derivatives.remove(EDerivativeUsage.Web3D, quality);
+                model.derivatives.createModelAsset(filepath, quality)
+                model.ins.quality.setValue(quality);
+                model.outs.updated.set();
+                selection.selectNode(model.node);
+            }
+        }).catch(e => {});
     }
 
     refresh()
@@ -170,7 +246,7 @@ export default class CVMediaManager extends CAssetManager
     refreshRoot()
     {
         if(this.assetManager.ins.baseUrlValid.value) {
-            super.refresh().then(() => this.rootUrlChanged());
+            this.refresh().then(() => this.rootUrlChanged());
         }
     }
 }

--- a/source/client/components/CVModelEditor.ts
+++ b/source/client/components/CVModelEditor.ts
@@ -1,0 +1,105 @@
+/**
+ * 3D Foundation Project
+ * Copyright 2019 Smithsonian Institution
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import Component, { Node } from "@ff/graph/Component";
+
+import Notification from "@ff/ui/Notification";
+import MessageBox from "@ff/ui/MessageBox";
+
+import CVMediaManager, { IAssetOpenEvent } from "./CVMediaManager";
+import { IFileInfo } from "client/../../libs/ff-scene/source/assets/WebDAVProvider";
+import ImportMenu from "client/ui/story/ImportMenu";
+import MainView from "client/ui/story/MainView";
+import CVDocumentProvider from "./CVDocumentProvider";
+import CVModel2 from "./CVModel2";
+import { EDerivativeUsage } from "client/schema/model";
+import CVAssetManager from "./CVAssetManager";
+import { IAssetTreeChangeEvent } from "client/../../libs/ff-scene/source/components/CAssetManager";
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+export default class CVModelEditor extends Component
+{
+    static readonly typeName: string = "CVModelEditor";
+    static readonly isSystemSingleton = true;
+    protected get mediaManager() {
+        return this.system.getMainComponent(CVMediaManager);
+    }
+    protected get assetManager(){
+        return this.getMainComponent(CVAssetManager);
+    }
+    protected get documentProvider() {
+        return this.getMainComponent(CVDocumentProvider);
+    }
+
+    create()
+    {
+        super.create();
+        this.mediaManager.on<IAssetOpenEvent>("asset-open", this.onOpenAsset, this);
+        this.mediaManager.on<IAssetTreeChangeEvent>("tree-change", this.onTreeChange, this);
+    }
+
+    dispose()
+    {
+        super.dispose();
+        this.mediaManager.off<IAssetOpenEvent>("asset-open", this.onOpenAsset, this);
+        this.mediaManager.off<IAssetTreeChangeEvent>("tree-change", this.onTreeChange, this);
+    }
+
+    protected onOpenAsset(event: IAssetOpenEvent)
+    {
+        console.log("Open asset : ", event.asset?.info);
+        // if there is no asset, close any current article
+        if(event.asset === null ) {
+            //Close
+        } else if (event.asset.info.name.toLowerCase().endsWith(".glb")) {
+           this.importModel(event.asset.info);
+        }
+    }
+
+    protected onTreeChange(event: IAssetTreeChangeEvent){
+        console.log("Tree change", event);
+    }
+
+    private importModel(file :IFileInfo){
+        const mainView : MainView = document.getElementsByTagName('voyager-story')[0] as MainView;
+        const activeDoc = this.documentProvider.activeComponent;
+        ImportMenu.show(mainView, activeDoc.setup.language, file.name).then(([quality, parentName]) => {
+            const model = this.getSystemComponents(CVModel2).find(element => element.node.name === parentName);
+            if(typeof model === "undefined") {
+                const newModel = activeDoc.appendModel(file.path, quality);
+                const name = parentName;
+                newModel.node.name = name;
+                newModel.ins.name.setValue(name);
+                newModel.ins.quality.setValue(quality);
+            }
+            else {
+                model.derivatives.remove(EDerivativeUsage.Web3D, quality);
+                model.derivatives.createModelAsset(file.path, quality)
+                model.ins.quality.setValue(quality);
+                model.outs.updated.set();
+            }
+        }).catch(e => {
+            if(e){
+                console.error(e);
+                Notification.show(`Failed to edit model : ${e.message}`, "error");
+            }
+        });
+    }
+}

--- a/source/client/components/CVStandaloneFileManager.ts
+++ b/source/client/components/CVStandaloneFileManager.ts
@@ -22,7 +22,7 @@ import CVDocumentProvider from "./CVDocumentProvider";
 
 import Notification from "@ff/ui/Notification";
 
-import { SimpleDropzone } from 'simple-dropzone';
+//import { SimpleDropzone } from 'simple-dropzone';
 import ExplorerApplication from "client/applications/ExplorerApplication";
 import MainView from "client/ui/story/MainView";
 import CVMediaManager from "./CVMediaManager";
@@ -140,18 +140,18 @@ export default class CVStandaloneFileManager extends Component
 
     update()
     {
-        if(!this.isConfigured) {
+        /*if(!this.isConfigured) {
             const explorerPanel = document.getElementsByClassName('sv-explorer-panel')[0];
             const input = document.querySelector('#fileInput');
             const dropZone = new SimpleDropzone(explorerPanel, input);
             dropZone.on('drop', ({files}: any) => this.onFileDrop(files));
             this.isConfigured = true;
-        }
+        }*/
 
         return false;
     }
     
-    protected onFileDrop(files: Map<string, File>)
+    onFileDrop(files: Map<string, File>)
     {
         const fileArray = Array.from(files);
         const hasDoc = this.documentLoaded;

--- a/source/client/components/CVStandaloneFileManager.ts
+++ b/source/client/components/CVStandaloneFileManager.ts
@@ -1,6 +1,6 @@
 /**
  * 3D Foundation Project
- * Copyright 2019 Smithsonian Institution
+ * Copyright 2023 Smithsonian Institution
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,9 @@ import Component, { Node } from "@ff/graph/Component";
 import CVAssetManager from "./CVAssetManager";
 import CVDocumentProvider from "./CVDocumentProvider";
 
-import Notification from "@ff/ui/Notification";
-
-//import { SimpleDropzone } from 'simple-dropzone';
-import ExplorerApplication from "client/applications/ExplorerApplication";
-import MainView from "client/ui/story/MainView";
 import CVMediaManager from "./CVMediaManager";
 import { IFileInfo } from "client/../../libs/ff-scene/source/components/CAssetManager";
 import { Dictionary } from "client/../../libs/ff-core/source/types";
-import ImportMenu from "client/ui/story/ImportMenu";
-import CVModel2 from "./CVModel2";
-import { EDerivativeUsage } from "client/schema/model";
 import CSelection from "client/../../libs/ff-graph/source/components/CSelection";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -44,11 +36,6 @@ export default class CVStandaloneFileManager extends Component
     private runtimeURLs: Array<string> = [];
     private fileMap: Dictionary<File> = {};
     private rootMap = {};
-    private importQueue: string[] = [];
-
-
-    private isConfigured: boolean = null;
-    private documentLoaded: boolean = false;
 
     protected get documentProvider() {
         return this.getMainComponent(CVDocumentProvider);
@@ -76,6 +63,28 @@ export default class CVStandaloneFileManager extends Component
         this.fileMap["/"] = null;  // needs base path for asset tree to generate correctly
         this.fileMap["articles/"] = null;
         this.mediaManager.refresh();
+
+        // add url modifier callback to return correct url
+        this.assetManager.loadingManager.setURLModifier( ( url ) => {
+            
+            url = decodeURI(url);
+            const index = url.lastIndexOf('/');
+            const filename = url.substr(index + 1).replace(/^(\.?\/)/, '');
+            
+            const baseURL = this.rootMap[filename] + filename;
+            const normalizedURL = baseURL.startsWith("/") ? baseURL.substr(1) : baseURL;  // strip potential leading slash
+            
+            if(this.runtimeURLs[normalizedURL]) {
+                return this.runtimeURLs[normalizedURL];
+            }
+            if(this.fileMap[normalizedURL]) {
+                const bloburl = URL.createObjectURL( this.fileMap[normalizedURL] );
+                this.runtimeURLs[normalizedURL] = bloburl;
+                return bloburl;
+            } 
+            
+            return url;
+        } );
     }
 
     dispose()
@@ -101,16 +110,28 @@ export default class CVStandaloneFileManager extends Component
     
     addFile(uri: string, data: BlobPart[] = [])
     {
+        // add folders to map
+        const parts = uri.split("/").filter(part => !!part);
+        let folderPath = "";
+        for (let i = 0, nj = parts.length-1; i < nj; i++) {
+            folderPath = folderPath.concat(parts[i], "/");
+            this.fileMap[folderPath] = null;
+        }
+
         const idx = uri.lastIndexOf("/");
         const filename = idx > -1 ? uri.substr(idx + 1) : uri;
         const rootPath = uri.replace(filename, '');
+        
+        const normalizedURL = uri.startsWith("/") ? uri.substr(1) : uri;  // strip potential leading slash
 
         this.rootMap[filename] = rootPath;
-        this.fileMap[uri] = new File(data, filename);
+        this.fileMap[normalizedURL] = new File(data, filename);
 
-        if(this.runtimeURLs[uri]) {
-            this.runtimeURLs[uri] = null;
+        if(this.runtimeURLs[normalizedURL]) {
+            this.runtimeURLs[normalizedURL] = null;
         }
+
+        this.mediaManager.refresh();
     }
 
     deleteFile(uri: string)
@@ -138,106 +159,17 @@ export default class CVStandaloneFileManager extends Component
         return Object.keys(urlList).find(key => urlList[key] === bloburl);
     }
 
-    update()
-    {
-        /*if(!this.isConfigured) {
-            const explorerPanel = document.getElementsByClassName('sv-explorer-panel')[0];
-            const input = document.querySelector('#fileInput');
-            const dropZone = new SimpleDropzone(explorerPanel, input);
-            dropZone.on('drop', ({files}: any) => this.onFileDrop(files));
-            this.isConfigured = true;
-        }*/
+    reload() {
+        this.cleanupFiles();
+        this.runtimeURLs.length = 0;
+        this.fileMap = {};
+        this.rootMap = {};
 
-        return false;
+        this.fileMap["/"] = null;  // needs base path for asset tree to generate correctly
+        this.fileMap["articles/"] = null;
+        this.mediaManager.refresh();
     }
     
-    onFileDrop(files: Map<string, File>)
-    {
-        const fileArray = Array.from(files);
-        const hasDoc = this.documentLoaded;
-        
-        const docIndex = fileArray.findIndex( (element) => { return element[0].toLowerCase().indexOf(".svx.json") > -1 });
-        const documentProvided : boolean = docIndex > -1;
-        if(documentProvided) {
-            fileArray.push(fileArray.splice(docIndex,1)[0]);
-
-            if(hasDoc) {
-                this.reload();
-            }
-
-            this.documentLoaded = true;
-        }
-        const documentRoot = documentProvided ? fileArray[fileArray.length-1][0].replace(fileArray[fileArray.length-1][1].name, '') : "";
-
-        fileArray.forEach(([path, file]) => {
-            const cleanfileName = decodeURI(file.name);
-            const filenameLower = cleanfileName.toLowerCase();
-            if (filenameLower.match(/\.(gltf|glb|bin|svx.json|html|jpg|png|usdz)$/)) {
-
-                if(!documentProvided && filenameLower.match(/\.(jpg|png)$/) && !fileArray.some(entry => entry[0].endsWith("gltf"))) {
-                    path = CVMediaManager.articleFolder + "/" + cleanfileName;
-                }
-
-                // add folders to map
-                const parts = path.split("/").filter(part => !!part);
-                let folderPath = "";
-                for (let i = 0, nj = parts.length-1; i < nj; i++) {
-                    folderPath = folderPath.concat(parts[i], "/");
-                    this.fileMap[folderPath] = null;
-                }
-
-                // normalize path relative to document root
-                path = documentProvided ? path.replace(documentRoot, '') : (path.startsWith("/") ? path.substr(1) : path);
-                const rootPath = path.replace(cleanfileName, '');
-                this.rootMap[cleanfileName] = rootPath;
-                
-                this.fileMap[path] = file;
-
-                this.assetManager.loadingManager.setURLModifier( ( url ) => {
-
-                    url = decodeURI(url);
-                    const index = url.lastIndexOf('/');
-                    const filename = url.substr(index + 1).replace(/^(\.?\/)/, '');
-
-                    const baseURL = this.rootMap[filename] + filename;
-                    const normalizedURL = baseURL.startsWith("/") ? baseURL.substr(1) : baseURL;  // strip potential leading slash
-
-                    if(this.runtimeURLs[normalizedURL]) {
-                        return this.runtimeURLs[normalizedURL];
-                    }
-                    if(this.fileMap[normalizedURL]) {
-                        const bloburl = URL.createObjectURL( this.fileMap[normalizedURL] );
-                        this.runtimeURLs[normalizedURL] = bloburl;
-                        return bloburl;
-                    } 
-
-                    return url;
-                } );
-
-                if (!documentProvided && filenameLower.match(/\.(gltf|glb)$/)) {
-                    this.importQueue.push(path);
-                }
-                else if (filenameLower.match(/\.(svx.json)$/)) {
-                    const mainView : MainView = document.getElementsByTagName('voyager-story')[0] as MainView;
-                    const explorer : ExplorerApplication = mainView.app.explorerApp;
-            
-                    explorer.loadDocument(path);
-                    this.documentProvider.refreshDocument();
-                    
-                    //this.assetReader.getJSON(path).then(data => this.documentProvider.createDocument(data, path))
-                }
-            }
-            else {
-                new Notification(`Unhandled file: '${cleanfileName}'`, "warning", 4000);
-            }
-        });
-
-        if(this.importQueue.length > 0) {
-            this.handleModelImport(this.importQueue.pop());
-        }
-        this.mediaManager.refresh(); 
-    }
-
     protected cleanupFiles() 
     {
         this.runtimeURLs.forEach(( url ) => URL.revokeObjectURL( url ));
@@ -273,47 +205,5 @@ export default class CVStandaloneFileManager extends Component
         info.path = path;
 
         return info as IFileInfo;
-    }
-
-    protected handleModelImport(filepath: string) {
-        const mainView : MainView = document.getElementsByTagName('voyager-story')[0] as MainView;
-        const activeDoc = this.documentProvider.activeComponent;
-        const importQueue = this.importQueue;
-        const filename = this.fileMap[filepath].name;
-
-        ImportMenu.show(mainView, activeDoc.setup.language, filename).then(([quality, parentName]) => {
-            const model = this.getSystemComponents(CVModel2).find(element => element.node.name === parentName);
-            if(model === undefined) {
-                // converting path to relative (TODO: check if all browsers will have leading slash here)
-                const newModel = activeDoc.appendModel(filepath, quality);
-                const name = parentName;
-                newModel.node.name = name;
-                newModel.ins.name.setValue(name);
-                newModel.ins.quality.setValue(quality);
-                this.selection.selectNode(newModel.node);
-            }
-            else {
-                model.derivatives.remove(EDerivativeUsage.Web3D, quality);
-                model.derivatives.createModelAsset(filepath, quality)
-                model.ins.quality.setValue(quality);
-                model.outs.updated.set();
-                this.selection.selectNode(model.node);
-            }
-
-            if(importQueue.length > 0) {
-                this.handleModelImport(importQueue.pop());
-            }
-        }).catch(e => {});
-    }
-
-    protected reload() {
-        this.cleanupFiles();
-        this.runtimeURLs.length = 0;
-        this.fileMap = {};
-        this.rootMap = {};
-
-        this.fileMap["/"] = null;  // needs base path for asset tree to generate correctly
-        this.fileMap["articles/"] = null;
-        this.mediaManager.refresh();
     }
 }

--- a/source/client/ui/story/ArticleEditor.ts
+++ b/source/client/ui/story/ArticleEditor.ts
@@ -1,6 +1,6 @@
 /**
  * 3D Foundation Project
- * Copyright 2019 Smithsonian Institution
+ * Copyright 2023 Smithsonian Institution
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,6 +157,7 @@ export default class ArticleEditor extends SystemView
         content = content.replace(/(src=\")(.*?)(\")/g, (match, pre, assetUrl, post) => {
             if((assetUrl as string).startsWith("blob")) {
                 assetUrl = this.standaloneFileManager.blobUrlToFileUrl(assetUrl);
+                assetUrl = assetUrl.replace(CVMediaManager.articleFolder + "/", '');
                 return pre + assetUrl + post;
             }
 

--- a/source/client/ui/story/AssetPanel.ts
+++ b/source/client/ui/story/AssetPanel.ts
@@ -47,7 +47,7 @@ export default class AssetPanel extends DocumentView
     protected render()
     {
         const mode = this.taskProvider.ins.mode.value;
-        this.basePath = mode === ETaskMode.Expert ? "" : "articles";
+        this.basePath = "";
 
         return html`<div class="sv-panel-header">
                 <ff-button icon="folder" title="Create Folder" @click=${this.onClickFolder}></ff-button>

--- a/source/client/ui/story/DerivativeList.ts
+++ b/source/client/ui/story/DerivativeList.ts
@@ -18,7 +18,7 @@
 import { customElement, property, html } from "@ff/ui/CustomElement";
 import List from "@ff/ui/List";
 
-import Derivative, { EDerivativeUsage, EDerivativeQuality } from "../../models/Derivative";
+import Derivative, { EDerivativeUsage, EDerivativeQuality} from "../../models/Derivative";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -48,9 +48,11 @@ class DerivativeList extends List<Derivative>
     protected renderItem(item: Derivative)
     {
         const isLoaded = item === this.loadedItem;
-
-        return html`<ff-icon name=${isLoaded ? "check" : "empty"}></ff-icon>
-            <span>${EDerivativeUsage[item.data.usage]} - ${EDerivativeQuality[item.data.quality]}</span>`;
+        return html`<div style="display:flex;justify-content:stretch;">
+            <ff-icon name=${isLoaded ? "check" : "empty"}></ff-icon>
+            <span title=${item.data.assets.map(a=>a.data.uri).join("\n")} style="flex: 1 1 auto;">${EDerivativeUsage[item.data.usage]} - ${EDerivativeQuality[item.data.quality]}</span>
+            <ff-icon name="trash" @click=${(e)=>this.onRemoveItem(e, item)}></ff-icon>
+        </div>`;
     }
 
     protected isItemSelected(item: Derivative)
@@ -63,6 +65,14 @@ class DerivativeList extends List<Derivative>
         this.dispatchEvent(new CustomEvent("select", {
             detail: { derivative: item }
         }));
+    }
+
+    protected onRemoveItem(event :MouseEvent, item :Derivative){
+        event.stopPropagation();
+        this.dispatchEvent(new CustomEvent("remove", {
+            detail: { derivative: item }
+        }));
+        return false;
     }
 
     protected onClickEmpty(event: MouseEvent)

--- a/source/client/ui/story/DerivativeMenu.ts
+++ b/source/client/ui/story/DerivativeMenu.ts
@@ -107,6 +107,11 @@ export default class DerivativeMenu extends Popup
         </div>`;
     }
 
+    private hasModel = (node :IAssetEntry)=>{
+        return /\.(gltf|glb|usdz)$/.test(node.info.name)
+            || node.children.some(this.hasModel);
+    }
+
     protected render()
     {
         const language = this.system.getComponent(CVLanguageManager);
@@ -142,7 +147,7 @@ export default class DerivativeMenu extends Popup
                 </div>
                 <div class="ff-splitter-section">
                     <div class="ff-scroll-y">
-                        <ff-asset-tree class="ff-flex-item-stretch" .system=${this.system} path=""></ff-asset-tree>
+                        <ff-asset-tree class="ff-flex-item-stretch" .filter=${this.hasModel} .system=${this.system} path=""></ff-asset-tree>
                     </div>
                 </div>
                 <div class="ff-flex-row sv-centered">

--- a/source/client/ui/story/DerivativeMenu.ts
+++ b/source/client/ui/story/DerivativeMenu.ts
@@ -1,0 +1,174 @@
+/**
+ * 3D Foundation Project
+ * Copyright 2021 Smithsonian Institution
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Popup, { customElement, html } from "@ff/ui/Popup";
+
+import "@ff/ui/Button";
+import "@ff/ui/TextEdit";
+import CVLanguageManager from "client/components/CVLanguageManager";
+import { EDerivativeQuality, EDerivativeUsage, TDerivativeQuality, TDerivativeUsage } from "client/schema/model";
+import CVAssetManager from "client/components/CVAssetManager";
+import CVMediaManager from "client/components/CVMediaManager";
+import System from "@ff/graph/System";
+import { IAssetEntry } from "@ff/scene/components/CAssetManager";
+
+////////////////////////////////////////////////////////////////////////////////
+
+@customElement("sv-derivative-menu")
+export default class DerivativeMenu extends Popup
+{
+    protected url: string;
+    protected system :System = null;
+    protected files: string[] = [];
+    protected errorString: string = "";
+    protected qualitySelection: EDerivativeQuality = null;
+    protected usageSelection: EDerivativeUsage = EDerivativeUsage["Web3D"];
+
+    static show(parent: HTMLElement, system :System): Promise<[EDerivativeUsage, EDerivativeQuality, IAssetEntry]>
+    {
+        const menu = new DerivativeMenu(system);
+        parent.appendChild(menu);
+
+        return new Promise((resolve, reject) => {
+            menu.on("confirm", () => resolve([menu.usageSelection, menu.qualitySelection, menu.mediaManager.selectedAssets[0]]));
+            menu.on("close", () => reject());
+        });
+    }
+
+    get mediaManager(){
+        return this.system.getMainComponent(CVMediaManager);
+    }
+
+    constructor( system :System)
+    {
+        super();
+
+        this.system = system;
+        this.position = "center";
+        this.modal = true;
+
+        this.url = window.location.href;
+    }
+
+    close()
+    {
+        this.dispatchEvent(new CustomEvent("close"));
+        this.remove();
+    }
+
+    confirm()
+    {
+        if(this.usageSelection === null) {
+            this.errorString = "Please select derivative usage.";
+            this.requestUpdate();
+        } else if(this.qualitySelection === null) {
+            this.errorString = "Please select derivative quality.";
+            this.requestUpdate();
+        } else if(!/\.(glb|gltf|usdz)/i.test(this.mediaManager.selectedAssets[0]?.info.name)){
+            this.errorString = "Please select a model file";
+            this.requestUpdate();
+        } else {
+            this.dispatchEvent(new CustomEvent("confirm"));
+            this.remove();
+        }
+    }
+
+    protected firstConnected()
+    {
+        super.firstConnected();
+        this.classList.add("sv-option-menu", "sv-import-menu");
+    }
+
+    protected renderQualityEntry(quality: EDerivativeQuality, index: number)
+    {
+        return html`<div class="sv-entry" @click=${e => this.onClickQuality(e, index)} ?selected=${ quality === this.qualitySelection }>
+            ${EDerivativeQuality[quality] as TDerivativeQuality}
+        </div>`;
+    }
+
+    protected renderUsageEntry(usage: EDerivativeUsage, index: number)
+    {
+        return html`<div class="sv-entry" @click=${e => this.onClickUsage(e, index)} ?selected=${ usage === this.usageSelection }>
+            ${EDerivativeUsage[usage] as TDerivativeUsage}
+        </div>`;
+    }
+
+    protected render()
+    {
+        const language = this.system.getComponent(CVLanguageManager);
+        return html`
+        <div>
+            <div class="ff-flex-column ff-fullsize">
+                <div class="ff-flex-row">
+                    <div class="ff-flex-spacer ff-title">${"Add Derivative"} :</div>
+                    <ff-button icon="close" transparent class="ff-close-button" title=${language.getLocalizedString("Close")} @click=${this.close}></ff-button>
+                </div>
+                <div class="ff-flex-row">
+                    <div class="ff-flex-spacer ff-header">${language.getLocalizedString("Select Derivative Usage")}:</div>
+                </div>
+                ${this.usageSelection===null? html`<div class="ff-splitter-section">
+                    <div class="ff-scroll-y">
+                        ${Object.keys(EDerivativeUsage).filter(key => typeof EDerivativeUsage[key] === 'number').map((key, index) => this.renderUsageEntry(EDerivativeUsage[key], index))}
+                    </div>
+                </div>` : html`<div class="ff-flex-row">
+                    <ff-button selected style="flex:1 1 auto;" text="${ EDerivativeUsage[this.usageSelection] }" @click=${()=> {this.usageSelection = null; this.requestUpdate()}}></ff-button>
+                </div>`}
+                <div class="ff-flex-row">
+                    <div class="ff-flex-spacer ff-header">${language.getLocalizedString("Select Derivative Quality")}:</div>
+                </div>
+                ${this.qualitySelection === null? html`<div class="ff-splitter-section">
+                    <div class="ff-scroll-y">
+                        ${Object.keys(EDerivativeQuality).filter(key => typeof EDerivativeQuality[key] === 'number').map((key, index) => this.renderQualityEntry(EDerivativeQuality[key], index))}
+                    </div>
+                </div>`: html`<div class="ff-flex-row">
+                    <ff-button selected style="flex:1 1 auto;" text="${ EDerivativeQuality[this.qualitySelection] }" @click=${()=> {this.qualitySelection = null; this.requestUpdate()}}></ff-button>
+                </div>`}
+                <div class="ff-flex-row">
+                    <div class="ff-flex-spacer ff-header">${language.getLocalizedString("Select Model")}:</div>
+                </div>
+                <div class="ff-splitter-section">
+                    <div class="ff-scroll-y">
+                        <ff-asset-tree class="ff-flex-item-stretch" .system=${this.system} path=""></ff-asset-tree>
+                    </div>
+                </div>
+                <div class="ff-flex-row sv-centered">
+                    <ff-button icon="upload" class="ff-button ff-control" text=${language.getLocalizedString("Set Derivative")} title=${language.getLocalizedString("Import Model")} @click=${this.confirm}></ff-button>
+                </div>
+                <div class="ff-flex-row sv-centered sv-import-error-msg">
+                    <div>${this.errorString}</div>
+                </div>
+            </div>
+        </div>
+        `;
+    }
+
+    protected onClickQuality(e: MouseEvent, index: number)
+    {
+        e.stopPropagation();
+
+        this.qualitySelection = EDerivativeQuality[EDerivativeQuality[index]];
+        this.requestUpdate();
+    }
+
+    protected onClickUsage(e: MouseEvent, index: number)
+    {
+        e.stopPropagation();
+
+        this.usageSelection = EDerivativeUsage[EDerivativeUsage[index]];
+        this.requestUpdate();
+    }
+}

--- a/source/client/ui/story/DerivativesTaskView.ts
+++ b/source/client/ui/story/DerivativesTaskView.ts
@@ -103,6 +103,6 @@ export default class DerivativesTaskView extends TaskView<CVDerivativesTask>
             this.model.ins.quality.setValue(quality);
             this.model.outs.updated.set();
             this.system.getMainComponent(CSelection).selectNode(this.model.node);
-        }).catch(e=>Notification.show("Failed to add derivative : "+e.message, "error"));
+        }).catch(e=>{if(e) Notification.show("Failed to add derivative : "+e.message, "error")});
     }
 }

--- a/source/client/ui/story/ExplorerPanel.ts
+++ b/source/client/ui/story/ExplorerPanel.ts
@@ -21,6 +21,9 @@ import ExplorerView from "../explorer/MainView";
 import CustomElement, { customElement, property } from "@ff/ui/CustomElement";
 import ExplorerLockToolbar from "./ExplorerLockToolbar";
 import { relative } from "path";
+import { IStoryApplicationProps } from "client/applications/StoryApplication";
+import { SimpleDropzone } from 'simple-dropzone';
+import CVMediaManager from "client/components/CVMediaManager";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -35,7 +38,7 @@ export default class ExplorerPanel extends CustomElement
         super();
         this.application = application;
 
-        if(application.system.getComponent("CVStandaloneFileManager", true)) {
+        if((application.props as IStoryApplicationProps).dragdrop === true) {
             this.addEventListener('dragenter', this.onDragEnter);
             this.addEventListener('dragleave', this.onDragLeave);
             this.addEventListener('drop', this.onDragDrop);
@@ -44,6 +47,11 @@ export default class ExplorerPanel extends CustomElement
             fileInput.type = "file";
             fileInput.id = "fileInput";
             fileInput.style.display = "none";
+
+            const dropZone = new SimpleDropzone(this, fileInput);
+
+            const mediaManager = application.system.getComponent(CVMediaManager);
+            dropZone.on('drop', ({files}: any) => mediaManager.ingestFiles(files));
         }
     }
 

--- a/source/client/ui/story/ExplorerPanel.ts
+++ b/source/client/ui/story/ExplorerPanel.ts
@@ -24,6 +24,7 @@ import { relative } from "path";
 import { IStoryApplicationProps } from "client/applications/StoryApplication";
 import { SimpleDropzone } from 'simple-dropzone';
 import CVMediaManager from "client/components/CVMediaManager";
+import Tree from "@ff/ui/Tree";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -88,8 +89,17 @@ export default class ExplorerPanel extends CustomElement
         this.classList.remove("sv-drop-zone");
     }
 
-    protected onDragDrop(e: MouseEvent) {
+    protected onDragDrop(e: DragEvent) {
         e.preventDefault();
         this.classList.remove("sv-drop-zone");
+        for(let item of e.dataTransfer.items){
+            if(item.type !== Tree.dragDropMimeType) continue;
+            let mediaManager = this.application.system.getComponent(CVMediaManager);
+            item.getAsString((s)=>{
+                let asset = mediaManager.getAssetByPath(s);
+                //Undefined behavior if multiple assets are openned
+                mediaManager.open(asset);
+            });
+        }
     }
 }

--- a/source/client/ui/story/MainView.ts
+++ b/source/client/ui/story/MainView.ts
@@ -117,6 +117,7 @@ export default class MainView extends CustomElement
                 referrer: this.getAttribute("referrer"),
                 mode: this.getAttribute("mode"),
                 expert: this.hasAttribute("expert"),
+                dragdrop: this.hasAttribute("dragdrop"),
 
                 uiMode: this.getAttribute("uiMode"),
             };

--- a/source/client/ui/story/NodeTree.ts
+++ b/source/client/ui/story/NodeTree.ts
@@ -148,6 +148,12 @@ class NodeTree extends Tree<NVNode>
         }
     }
 
+
+    protected onNodeDblClick(event: MouseEvent, node: NVNode)
+    {
+        
+    }
+
     protected onContainerClick()
     {
         this.nodeProvider.activeNode = null;

--- a/source/client/ui/story/SettingsTaskView.ts
+++ b/source/client/ui/story/SettingsTaskView.ts
@@ -101,7 +101,6 @@ export class SettingsTree extends Tree<ITreeNode>
     protected createNodeTreeNode(node: Node): ITreeNode
     {
         const components = node.components.getArray().filter(component => component["settingProperties"]);
-
         return {
             id: node.id,
             text: node.displayName,


### PR DESCRIPTION
So I prototyped something that you might want to have:

I wanted to manage my 3D files in the way of **Standalone** mode but using the normal backend.

As a first step, I retrofitted the `ImportMenu.show()` to be called when the user double-clicks on a model in the `AssetTree`,  like what happens with the `ArticleEditor`.

It allows users to define new derivatives for a model or create a new model in the scene.

In my mind, the finished feature would contain the following : 

- Upon uploading a new model (drag & drop into asset-tree), `ImportMenu.show()` is shown to assign it to the scene
- An UI element should be created to un-assign derivatives to a model, to provide a way to correct mistakes Probably something like a double-click on the model in the **Navigator** tab?

Ideally I'd also like to make the `CVStandaloneFileManager` general-purpose to allow users to drag-drop into the main frame. The methods designed to get/set files could be isolated into another class, possibly simplifying the conditionals in `CVMediaManager`, `CVAssetWriter`, and others.

As I understand it those features are not required to your workflow but would you be open to merge them if done properly? Or do you think it would break how you expect the application to behave in a way I didn't understand?
