### PR TITLE
use native Material.copy method

### DIFF
--- a/source/client/io/ModelReader.ts
+++ b/source/client/io/ModelReader.ts
@@ -119,7 +119,7 @@ export default class ModelReader
 
                 // copy properties from previous material
                 if (material.type === "MeshStandardMaterial") {
-                    uberMat.copyStandardMaterial(material);
+                    uberMat.copy(material);
                 }
 
                 // check if the material's normal map uses object space (indicated in glTF extras)

--- a/source/client/shaders/UberPBRMaterial.ts
+++ b/source/client/shaders/UberPBRMaterial.ts
@@ -253,31 +253,4 @@ export default class UberPBRMaterial extends MeshStandardMaterial
     enableZoneMap(enabled) {
         this.defines["USE_ZONEMAP"] = enabled;
     }
-
-    copyStandardMaterial(material: MeshStandardMaterial): this
-    {
-        this.color = material.color;
-        this.opacity = material.opacity;
-        this.transparent = material.opacity < 1 || !!material.alphaMap || material.transparent;
-        this.alphaTest = material.alphaTest;
-
-        this.roughness = material.roughness;
-        this.roughnessMap = material.roughnessMap;
-
-        this.metalness = material.metalness;
-        this.metalnessMap = material.metalnessMap;
-
-        this.map = material.map;
-        this.aoMap = material.aoMap;
-        this.aoMapIntensity = material.aoMapIntensity;
-
-        this.normalMap = material.normalMap;
-
-        this.shadowSide = material.shadowSide;
-        //this.side = material.side;
-
-        this.flatShading = material.flatShading;
-
-        return this;
-    }
 }


### PR DESCRIPTION
So I noticed the `UberPBRMaterial` was missing the emissive map from one of my models.

I checked why and found `UberPBRMaterial.copyStandardMaterial()`was simply not copying it.

Instead of just adding it I wondered if other properties were missed in the copy and it turns out a whole bunch of them were.

The native `Material.copy()`method from THREE (code [here](https://github.com/mrdoob/three.js/blob/dev/src/materials/Material.js#L404)) seems to do the job, with the added benefit of being maintained upstream.

I tested it on my models and it looked right, fixing the missing emissive and not breaking anything. i'd like to know if it breaks anything for you, or if  you would rather only include the required properties in `copyStandardMaterial`.

