### PR TITLE
add button in tinyMCE to edit raw html code

### DIFF
--- a/source/client/ui/story/ArticleEditor.ts
+++ b/source/client/ui/story/ArticleEditor.ts
@@ -34,6 +34,7 @@ import 'tinymce/plugins/link';
 import 'tinymce/plugins/lists';
 import 'tinymce/plugins/image';
 import 'tinymce/plugins/media';
+import 'tinymce/plugins/code';
 
 /* Import content css */
 import contentUiCss from '!!raw-loader!./editor_css/content.ui.min.css';
@@ -201,8 +202,8 @@ export default class ArticleEditor extends SystemView
 
         tinymce.init({
             selector: "#editor_wrapper",
-            plugins: "image link lists media",
-            toolbar: 'saveButton closeButton | undo redo | link image media | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist | outdent indent | styles',
+            plugins: "image link lists media code",
+            toolbar: 'saveButton closeButton | undo redo | link image media | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist | outdent indent | styles |code',
             menubar: false,
             skin: false,
             height: "100%",


### PR DESCRIPTION
I have some user that want to get more creative with their article's layout.

The [Code Plugin](https://www.tiny.cloud/docs/tinymce/6/code/) shipped with tinyMCe seems OK enough for them.

I've tested some basic things like two-columns layout, image styling. It's obviously a "use at your own risk" feature, but any required security sanitization should be done on the server anyways.