### PR TITLE
Use UI language to create new articles

### DIFF
--- a/assets/language/string.resources.fr.json
+++ b/assets/language/string.resources.fr.json
@@ -41,6 +41,7 @@
   "Material": "Texture",
   "Measure": "Mesure",
   "Measured Distance": "Distance mesurée",
+  "New Article": "Nouvel Article",
   "No tour selected": "Pas de visite sélectionnée",
   "No tour steps defined": "Pas d'étapes de visites définies",
   "Normals": "Normales",

--- a/source/client/components/CVArticlesTask.ts
+++ b/source/client/components/CVArticlesTask.ts
@@ -287,18 +287,19 @@ export default class CVArticlesTask extends CVTask
 
         if (meta && article && meta.articles.getById(article.id)) {
             article = meta.articles.getById(article.id);
-            ins.title.setValue(article.title, true);
-            ins.lead.setValue(article.lead, true);
-            ins.tags.setValue(article.tags.join(", "), true);
 
             // if we don't have a uri for this language, create one so that it is editable
-            if(article.uri === undefined) {
+            (article.uri ? Promise.resolve(): (()=>{
                 const defaultFolder = CVMediaManager.articleFolder;
                 article.uri = `${defaultFolder}/new-article-${article.id}-${ELanguageType[ins.language.value]}.html`;
-            }
-
-            ins.uri.setValue(article.uri, true);
-            outs.article.setValue(article);
+                return this.createEditArticle(article)
+            })()).then(()=>{
+                ins.title.setValue(article.title, true);
+                ins.lead.setValue(article.lead, true);
+                ins.tags.setValue(article.tags.join(", "), true);
+                ins.uri.setValue(article.uri, true);
+                outs.article.setValue(article);
+            });
         }
         else {
             ins.title.setValue("", true);

--- a/source/client/models/Article.ts
+++ b/source/client/models/Article.ts
@@ -111,7 +111,9 @@ export default class Article extends Document<IArticle>
         return {
             id: Document.generateId(),
             title: "New Article",
-            titles: {},
+            titles: {
+                [DEFAULT_LANGUAGE]: "New Article"
+            },
             lead: "",
             leads: {},
             tags: [],


### PR DESCRIPTION
This PR adresses 2 localization problems (yet unreported AFAIK) :
 1) In Story mode, If I create an article the  UI switches back to english to create the article, which is very confusing.
 2) When I switch to another language with the article edition panel open, the URI get auto-generated but the article is no longer automatically created.

This PR solves both problems independently. 

The first one is quite straightforward. It could have been done as a new method in the `Article` class but it seemed clearer this way.

The second one might warrant a review and may need to be changed. The way I do it is temporary unset the `CVReader.ins.currentId` until a new article is created (or an error is caught and reported). It works but I might have missed a better way to delay trying to load the article until it's created.

