### PR TITLE
accept PLY and OBJ files in ingestFiles

### DIFF
--- a/source/client/components/CVAssetReader.ts
+++ b/source/client/components/CVAssetReader.ts
@@ -107,7 +107,7 @@ export default class CVAssetReader extends Component
     async getGeometry(assetPath: string): Promise<THREE.BufferGeometry>
     {
         const url = this.assetManager.getAssetUrl(assetPath);
-        return this.geometryLoader.get(url);
+        return this.geometryLoader.get(url, assetPath.split(".").pop().toLowerCase());
     }
 
     async getTexture(assetPath: string): Promise<THREE.Texture>

--- a/source/client/io/GeometryReader.ts
+++ b/source/client/io/GeometryReader.ts
@@ -41,11 +41,11 @@ export default class GeometryReader
         return GeometryReader.extensions.indexOf(extension) >= 0;
     }
 
-    get(url: string): Promise<BufferGeometry>
+    get(url: string, extension =  url.split(".").pop().toLowerCase()): Promise<BufferGeometry>
     {
-        const extension = url.split(".").pop().toLowerCase();
+        return new Promise(async (resolve, reject) => {
 
-        return new Promise((resolve, reject) => {
+            
             if (extension === "obj") {
                 this.objLoader.load(url, result => {
                     const geometry = result.children[0].geometry;

--- a/source/client/models/Asset.ts
+++ b/source/client/models/Asset.ts
@@ -122,7 +122,7 @@ export default class Asset extends Document<IAsset, IAssetJSON>
     protected inflate(json: IAssetJSON, data: IAsset)
     {
         data.uri = json.uri;
-        data.mimeType = json.mimeType || "";
+        data.mimeType = json.mimeType;
         data.type = EAssetType[json.type];
         data.mapType = EMapType[json.mapType];
         data.byteSize = json.byteSize || 0;
@@ -134,6 +134,10 @@ export default class Asset extends Document<IAsset, IAssetJSON>
             if (data.type === undefined) {
                 console.warn(`failed to determine asset type from asset: ${data.uri}`);
             }
+        }
+
+        if(data.mimeType === undefined){
+            data.mimeType = this.guessAssetMimeType();
         }
     }
 

--- a/source/client/models/DerivativeList.ts
+++ b/source/client/models/DerivativeList.ts
@@ -163,8 +163,7 @@ export default class DerivativeList
 
         const derivative = this.getOrCreate(EDerivativeUsage.Web3D, quality);
 
-        const asset = new Asset();
-        asset.setModel(assetPath);
+        const asset = new Asset({uri:assetPath} as any);
         derivative.addAsset(asset);
 
         return derivative;


### PR DESCRIPTION
OBJ and PLY files were rejected from injestFiles, though theoretically supported.

As they are transmitted as Blob URL to `GeometryReader` in standalone mode, it required to pass the original extension as an additional optional parameter to work, with some other minor changes.

I now realize I rewrote most of `CVMediaManager.ingestFiles()` for no good reason. I find it more readable this way but  I can revert those changes if you prefer.
