### PR TITLE
fix a race condition in CVLanguageManager

### DIFF
--- a/source/client/components/CVLanguageManager.ts
+++ b/source/client/components/CVLanguageManager.ts
@@ -150,8 +150,9 @@ export default class CVLanguageManager extends Component
     protected updateLanguage = (language: ELanguageType) => 
     {
         const { ins, outs } = this;
-
-        outs.language.setValue(language);
-        this.emit<ITagUpdateEvent>({ type: "tag-update" });
+        if(ins.language.value === language){
+            outs.language.setValue(language);
+            this.emit<ITagUpdateEvent>({ type: "tag-update" });
+        }
     }
 }


### PR DESCRIPTION

- load the UI in french (using a query string or custom-element attribute)
- load a scene set-up to be in english (`setups[0].language.language = "EN"`in the scene file)

The language widget shows the scene as **english**, but it's (sometimes) displayed in french.

It is the result of a race condition: The french dictionary is requested before the document, then if it loads after the setup has been parsed, it changes back the output language.

This commit fixes it.

