### PR TITLE
fix bad value for promptVisible when readerVisible == true

### DIFF
--- a/source/client/ui/explorer/ContentView.ts
+++ b/source/client/ui/explorer/ContentView.ts
@@ -137,7 +137,7 @@ export default class ContentView extends DocumentView
 
             if(controls && promptEnabled) {
                 const isInUse = navigation.ins.isInUse.value;
-                promptVisible = !isLoading && isInitialLoad && !isInUse;
+                promptVisible = !isLoading && isInitialLoad && !isInUse && !readerVisible;
                 navigation.ins.promptActive.setValue(promptVisible);
             }
         }


### PR DESCRIPTION
in scenes where readerVisible == true, `<sv-action-prompt>` doesn't get rendered and `CVOrbitNavigation.tick()` then throws an error when trying to modify the prompt's style.

I choose to always disable the prompt when the reader is visible. Another choice might be to keep it when `readerPosition !== EReaderPosition.Overlay`. 