### PR TITLE
Mesh shadows management

### DIFF
--- a/source/client/components/CVModel2.ts
+++ b/source/client/components/CVModel2.ts
@@ -79,6 +79,8 @@ export default class CVModel2 extends CObject3D
         quality: types.Enum("Model.Quality", EDerivativeQuality, EDerivativeQuality.High),
         tags: types.String("Model.Tags"),
         renderOrder: types.Number("Model.RenderOrder", 0),
+        castShadow: types.Boolean("Model.CastShadow", true),
+        receiveShadow: types.Boolean("Model.ReceiveShadow",false),
         shadowSide: types.Enum("Model.ShadowSide", ESideType, ESideType.Back),
         activeTags: types.String("Model.ActiveTags"),
         autoLoad: types.Boolean("Model.AutoLoad", true),
@@ -116,6 +118,8 @@ export default class CVModel2 extends CObject3D
             this.ins.localUnits,
             this.ins.tags,
             this.ins.renderOrder,
+            this.ins.castShadow,
+            this.ins.receiveShadow,
             this.ins.shadowSide,
             this.ins.shader,
             this.ins.overlayMap,
@@ -235,6 +239,7 @@ export default class CVModel2 extends CObject3D
                 if (overrideActive) {
                     this.updateMaterial();
                 }
+                this.updateShadows();
             }
             else if (ins.visible.value && overrideActive && this.ins.hiddenOpacity.value > 0) {
                 this.object3D.visible = true;
@@ -284,6 +289,15 @@ export default class CVModel2 extends CObject3D
                 ins.roughness.changed || ins.metalness.changed || ins.occlusion.changed)) {
             this.updateMaterial();
         }
+
+        if(ins.shadowSide.changed){
+            this.updateShadowSide();
+        }
+
+        if(ins.castShadow.changed || ins.receiveShadow.changed){
+            this.updateShadows();
+        }
+
         if (ins.center.changed) {
             this.center();
         }
@@ -356,8 +370,11 @@ export default class CVModel2 extends CObject3D
         ins.tags.setValue(data.tags || "");
         ins.renderOrder.setValue(data.renderOrder !== undefined ? data.renderOrder : 0);
 
-        const side = ESideType[data.shadowSide || "Back"];
-        ins.shadowSide.setValue(isFinite(side) ? side : ESideType.Back);
+
+        ins.castShadow.setValue(data.castShadow ?? true);
+        ins.receiveShadow.setValue(data.receiveShadow ?? false);
+        const side = ESideType[data.shadowSide || "Default"];
+        ins.shadowSide.setValue(isFinite(side) ? side : ESideType.Default);
 
         ins.position.reset();
         ins.rotation.reset();
@@ -442,7 +459,13 @@ export default class CVModel2 extends CObject3D
         if (ins.renderOrder.value !== 0) {
             data.renderOrder = ins.renderOrder.value;
         }
-        if(ins.shadowSide.value != ESideType.Back) {
+        if(ins.castShadow.value !== true){
+            data.castShadow = ins.castShadow.value;
+        }
+        if(ins.receiveShadow.value !== false){
+            data.receiveShadow = ins.receiveShadow.value;
+        }
+        if(ins.shadowSide.value != ESideType.Default) {
             data.shadowSide = ESideType[this.ins.shadowSide.getValidatedValue()] as TSideType;
         }
 
@@ -552,6 +575,29 @@ export default class CVModel2 extends CObject3D
                 material.metalness = ins.metalness.value;
                 material.side = ins.doubleSided.value ? DoubleSide : FrontSide;
             }
+        });
+    }
+
+    protected updateShadowSide()
+    {
+        this.object3D.traverse(object => {
+            const material = object["material"] as UberPBRMaterial;
+            if (material && material.isUberPBRMaterial) {
+                material.shadowSide = {
+                    [ESideType.Front]: FrontSide,
+                    [ESideType.Back]: BackSide,
+                    [ESideType.Double]: DoubleSide,
+                }[this.ins.shadowSide.value] ?? null;
+            }
+        });
+    }
+
+    protected updateShadows()
+    {
+        this.object3D.traverse(object => {
+            if(object.type != "Mesh") return;
+            object.castShadow = this.ins.castShadow.value;
+            object.receiveShadow = this.ins.receiveShadow.value;
         });
     }
 
@@ -703,18 +749,8 @@ export default class CVModel2 extends CObject3D
                 }
 
                 // update shadow render side
-                if(this.ins.shadowSide.value != ESideType.Back) {
-                    this.object3D.traverse(object => {
-                        const material = object["material"] as UberPBRMaterial;
-                        if (material && material.isUberPBRMaterial) {
-                            if(this.ins.shadowSide.value == ESideType.Front) {
-                                material.shadowSide = FrontSide;
-                            }
-                            else {
-                                material.shadowSide = BackSide;
-                            }
-                        }
-                    });
+                if(this.ins.shadowSide.value != ESideType.Default) {
+                    this.updateShadowSide();
                 }
 
                 // flag environment map to update if needed

--- a/source/client/io/ModelReader.ts
+++ b/source/client/io/ModelReader.ts
@@ -106,7 +106,6 @@ export default class ModelReader
         scene.traverse((object: any) => {
             if (object.type === "Mesh") {
                 const mesh: Mesh = object;
-                mesh.castShadow = true;
                 const material = mesh.material as MeshStandardMaterial;
 
                 if (material.map) {

--- a/source/client/schema/json/model.schema.json
+++ b/source/client/schema/json/model.schema.json
@@ -230,6 +230,12 @@
         "overlayMap": {
             "type": "number"
         },
+        "castShadow": {
+            "type":"boolean"
+        },
+        "receiveShadow": {
+            "type": "boolean"
+        },
         "shadowSide": {
             "type": "string",
             "enum": [

--- a/source/client/schema/model.ts
+++ b/source/client/schema/model.ts
@@ -36,8 +36,8 @@ export type TAssetType = "Model" | "Geometry" | "Image" | "Texture" | "Points" |
 export enum EMapType { Color, Emissive, Occlusion, Normal, MetallicRoughness, Zone }
 export type TMapType = "Color" | "Emissive" | "Occlusion" | "Normal" | "MetallicRoughness" | "Zone";
 
-export enum ESideType { Front, Back, Double }
-export type TSideType = "Front" | "Back" | "Double";
+export enum ESideType { Front, Back, Double, Default }
+export type TSideType = "Front" | "Back" | "Double"| "Default";
 
 
 export interface IModel
@@ -49,6 +49,8 @@ export interface IModel
     visible?: boolean;
     renderOrder?: number;
     overlayMap?: number;
+    castShadow?: boolean;
+    receiveShadow?: boolean;
     shadowSide?: TSideType;
     translation?: Vector3;
     rotation?: Vector4;


### PR DESCRIPTION

- allow manually forcing shadowSide to Back (otherwise its default value is tied to material.side, see [the doc](https://threejs.org/docs/#api/en/materials/Material.shadowSide)
- add toggles for `castShadow` and `receiveShadow` on models (keeping previous defaults). castShadow was always enabled (in `ModelReader`). `receiveShadow` was always disabled but it's a nice touch to have on some models.

`shadowSide` can now be toggled without having to save and reload.


