### PR TITLE
keep user-selected language when creating a new annotation

### DIFF
--- a/source/client/components/CVAnnotationsTask.ts
+++ b/source/client/components/CVAnnotationsTask.ts
@@ -36,6 +36,7 @@ import AnnotationsTaskView from "../ui/story/AnnotationsTaskView";
 import CVScene from "client/components/CVScene";
 import { ELanguageStringType, ELanguageType, DEFAULT_LANGUAGE } from "client/schema/common";
 import { getMeshTransform } from "client/utils/Helpers";
+import { IAnnotation } from "client/schema/model";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -74,7 +75,6 @@ export default class CVAnnotationsTask extends CVTask
     constructor(node: Node, id: string)
     {
         super(node, id);
-
         const configuration = this.configuration;
         configuration.annotationsVisible = true;
         configuration.gridVisible = false;
@@ -215,6 +215,8 @@ export default class CVAnnotationsTask extends CVTask
 
     protected createAnnotation(position: number[], direction: number[])
     {
+        const languageManager = this.activeDocument.setup.language;
+        const language = this.ins.language.value;
         const annotations = this.activeAnnotations;
         if (!annotations) {
             return;
@@ -231,6 +233,8 @@ export default class CVAnnotationsTask extends CVTask
         const model = annotations.getComponent(CVModel2);
         const annotation = new Annotation(template);
 
+        annotation.language = language;
+        annotation.title = languageManager.getLocalizedString("New Annotation");
         const data = annotation.data;
         data.position = position;
         data.direction = direction;
@@ -244,7 +248,6 @@ export default class CVAnnotationsTask extends CVTask
         annotations.addAnnotation(annotation);
         annotations.activeAnnotation = annotation;
 
-        this.activeDocument.setup.language.ins.language.setValue(ELanguageType[DEFAULT_LANGUAGE]);
     }
 
     protected moveAnnotation(position: number[], direction: number[])

--- a/source/client/models/Annotation.ts
+++ b/source/client/models/Annotation.ts
@@ -111,7 +111,9 @@ export default class Annotation extends Document<IAnnotation, IAnnotation>
         return {
             id: Document.generateId(),
             title: "New Annotation",
-            titles: {},
+            titles: {
+                [DEFAULT_LANGUAGE]: "New Annotation"
+            },
             lead: "",
             leads: {},
             marker: "",


### PR DESCRIPTION
When creating a new annotation, UI-locale gets silently switched back to DEFAULT_LANGUAGE, due to this line:

```
this.activeDocument.setup.language.ins.language.setValue(ELanguageType[DEFAULT_LANGUAGE]);
```
(in `CVAnnotationsTask.createAnnotation()`)

Deleting the line exposes some undefined titles values which this commit fixes. It's pretty much the same as the outdated #203, but for annotations.

Should have no impact on users working in English.