### PR TITLE
use alpha mix for zonemap blend

### DIFF
--- a/source/client/shaders/uberPBRShader.frag
+++ b/source/client/shaders/uberPBRShader.frag
@@ -240,7 +240,7 @@ void main() {
 
 	#ifdef USE_ZONEMAP
 		vec4 zoneColor = texture2D(zoneMap, vZoneUv);
-		gl_FragColor += vec4(zoneColor.rgb, 1.0);
+		gl_FragColor += mix(gl_FragColor, vec4(zoneColor.rgb, 1.0), zoneColor.a);
 	#endif
 
 	#include <tonemapping_fragment>


### PR DESCRIPTION
While testing the "overlayMap" features, I noticed the `USE_ZONEMAP` GLSL fragment ignored the texture's alpha.

It completely break usage of PNG/Webp textures with transparency.

I propose updating the blend to a simple alpha mix that solves the problem.

Of course I can visually achieve the same result by putting a black background on my texture so it might not be considered a bug. However it's not consistent with how textures with alpha are generally handled.

Another reason I'd want this is to be able to add customizez "blend modes" for overlayMap in the future. The current "additive blend" cannot work on very light-colored models and that's bound to be a problem in some cases.

