### PR TITLE
fix USE_CLEARCOAT in main shader fragment

### DIFF
--- a/source/client/shaders/uberPBRShader.frag
+++ b/source/client/shaders/uberPBRShader.frag
@@ -226,7 +226,7 @@ void main() {
 
 		vec3 Fcc = F_Schlick( material.clearcoatF0, material.clearcoatF90, dotNVcc );
 
-		outgoingLight = outgoingLight * ( 1.0 - material.clearcoat * Fcc ) + ( clearcoatSpecularDirect + clearcoatSpecularIndirect ) * material.clearcoat;
+		outgoingLight = outgoingLight * ( 1.0 - material.clearcoat * Fcc ) + clearcoatSpecular * material.clearcoat;
 
 	#endif
 


### PR DESCRIPTION
The current implementation of clearcoat's outgoingLight references variables that don't exist in three v0.157.

When using a model that triggers `USE_CLEARCOAT`, we get an error : 
```

FRAGMENT

ERROR: 0:3265: 'clearcoatSpecularDirect' : undeclared identifier
ERROR: 0:3265: 'clearcoatSpecularIndirect' : undeclared identifier
```

I rolled back the line to match the current  implementation.

Updating three to a later version (r158 and up) would also be a valid fix but I don't know if it will break anything else.