### PR TITLE
register error in loadingManager when JSONWriter.put fails

### DIFF
--- a/source/client/io/JSONWriter.ts
+++ b/source/client/io/JSONWriter.ts
@@ -52,7 +52,9 @@ export default class JSONWriter
                 throw new Error(message);
             }
 
-            this._loadingManager.itemEnd(url);
+        }).then(()=>this._loadingManager.itemEnd(url), (e)=>{
+            this._loadingManager.itemError(url);
+            throw e;
         });
     }
 }


### PR DESCRIPTION
If for whatever reason `JSONWriter` fails to put the updated document, it causes loadingManager to be indefinitely busy.

This change properly registers the failure.