### PR TITLE
Fix #252 set mediaManager.rootUrl before calling baseUrlValid

### DIFF
--- a/source/client/applications/StoryApplication.ts
+++ b/source/client/applications/StoryApplication.ts
@@ -187,10 +187,10 @@ export default class StoryApplication
         }     
 
         // if dragging/dropping have to assume that a non-loading url is still valid
+        this.mediaManager.rootUrl = this.assetManager.baseUrl;
         if(props.dragdrop === true) {
             this.assetManager.ins.baseUrlValid.setValue(true);
         }
-        this.mediaManager.rootUrl = this.assetManager.baseUrl;
 
         const tasks = this.system.getMainComponent(CVTaskProvider);
         tasks.ins.mode.setValue(mode);


### PR DESCRIPTION
the previous order of operations would cause a request to be fired to the wrong URL if `root` is set to something other than `/<scene_name>`(eg. a `scenes` subfolder).