### PR TITLE
remove all references to ff-property-view and ff-property-field. Fix #257

### DIFF
--- a/source/client/ui/PropertyBoolean.ts
+++ b/source/client/ui/PropertyBoolean.ts
@@ -47,7 +47,7 @@ export default class PropertyBoolean extends CustomElement
 
     protected firstConnected()
     {
-        this.classList.add("sv-property-view", "sv-property-boolean");
+        this.classList.add("sv-property", "sv-property-boolean");
     }
 
     protected update(changedProperties: PropertyValues): void

--- a/source/client/ui/PropertyColor.ts
+++ b/source/client/ui/PropertyColor.ts
@@ -40,28 +40,16 @@ export default class PropertyColor extends CustomElement
     name = "";
 
     protected color: Color = new Color();
-    protected pickerActive = false;
 
     constructor()
     {
         super();
-        this.onPointerDown = this.onPointerDown.bind(this);
     }
 
     protected firstConnected()
     {
         super.firstConnected();
-        this.classList.add("sv-property-view", "sv-property-color");
-    }
-
-    protected connected()
-    {
-        document.addEventListener("pointerdown", this.onPointerDown, { capture: true, passive: true });
-    }
-
-    protected disconnected()
-    {
-        document.removeEventListener("pointerdown", this.onPointerDown);
+        this.classList.add("sv-property", "sv-property-color");
     }
 
     protected update(changedProperties: PropertyValues): void
@@ -95,66 +83,19 @@ export default class PropertyColor extends CustomElement
         const color = this.color.toString();
 
         return html`<label class="ff-label ff-off">${name}</label>
-            <ff-button style="background-color: ${color}" title="${name} Color Picker" @click=${this.onButtonClick}></ff-button>
-            ${this.pickerActive ? html`<ff-color-edit .color=${this.color} @keydown=${e =>this.onKeyDown(e)} @change=${this.onColorEditChange}></ff-color-edit>` : null}`;
+            <input type="color" value="${color}" @change=${this.onColorChange}>
+        `;
     }
 
-    protected async setPickerFocus()
+    protected onColorChange(event: Event)
     {
-        await this.updateComplete;
-        const container = this.getElementsByTagName("ff-color-edit").item(0) as HTMLElement;
-        (getFocusableElements(container)[0] as HTMLElement).focus();
-    }
-
-    protected onButtonClick(event: IButtonClickEvent)
-    {
-        this.pickerActive = !this.pickerActive;
-        this.requestUpdate();
-
-        if(this.pickerActive) {
-            this.setPickerFocus();
-        }
-    }
-
-    protected onColorEditChange(event: IColorEditChangeEvent)
-    {
-        this.property.setValue(event.detail.color.toRGBArray());
+        this.color = new Color((event.target as HTMLInputElement).value);
+        this.property.setValue(this.color.toRGBArray());
     }
 
     protected onPropertyChange(value: number[])
     {
         this.color.fromArray(value);
         this.requestUpdate();
-    }
-
-    // if color picker is active and user clicks outside, close picker
-    protected onPointerDown(event: PointerEvent)
-    {
-        if (!this.pickerActive) {
-            return;
-        }
-
-        if (event.composedPath()[0] instanceof Node && this.contains(event.composedPath()[0] as Node)) {
-            return;
-        }
-
-        this.pickerActive = false;
-        this.requestUpdate();
-    }
-
-    protected onKeyDown(e: KeyboardEvent)
-    {
-        if (e.code === "Escape") {
-            e.preventDefault();
-            e.stopPropagation();
-            this.pickerActive = false;
-            this.requestUpdate();
-
-            (this.getElementsByTagName("ff-button")[0] as HTMLElement).focus();
-        }
-        else if(e.code === "Tab") {
-            const element = this.getElementsByTagName("ff-color-edit")[0] as HTMLElement;
-            focusTrap(getFocusableElements(element) as HTMLElement[], e);
-        }
     }
 }

--- a/source/client/ui/PropertyEvent.ts
+++ b/source/client/ui/PropertyEvent.ts
@@ -40,7 +40,7 @@ export default class PropertyEvent extends CustomElement
 
     protected firstConnected()
     {
-        this.classList.add("sv-property-view", "sv-property-event");
+        this.classList.add("sv-property", "sv-property-event");
     }
 
     protected update(changedProperties: PropertyValues): void

--- a/source/client/ui/PropertyNumber.ts
+++ b/source/client/ui/PropertyNumber.ts
@@ -1,0 +1,198 @@
+
+import Property from "@ff/graph/Property";
+import CustomElement, { customElement, property, PropertyValues, html } from "@ff/ui/CustomElement";
+
+import "@ff/ui/Button";
+import PropertyField from "@ff/scene/ui/PropertyField";
+
+////////////////////////////////////////////////////////////////////////////////
+
+@customElement("sv-property-number")
+export default class PropertyNumber extends CustomElement
+{
+    @property({ attribute: false })
+    property: Property = null;
+
+    @property({ type: String })
+    name = "";
+
+    /**
+     * Handles vector properties by specifying an array index.
+     */
+    @property({ type: Number, reflect: false })
+    index = undefined;
+
+    delta :number;
+
+    get value(){
+        return typeof this.index ==="number"? this.property.value[this.index]: this.property.value
+    }
+
+    protected firstConnected()
+    {
+        this.classList.add("sv-property", "sv-property-number");
+        this.addEventListener("pointerdown", this.onPointerDown);
+        this.addEventListener("pointerup", this.onPointerUp);
+        this.addEventListener("pointercancel", this.onPointerUp);
+    }
+
+    
+    protected update(changedProperties: PropertyValues): void
+    {
+        if (!this.property) {
+            throw new Error("missing property attribute");
+        }
+
+        if (this.property.type !== "number") {
+            throw new Error("not an number property");
+        }
+
+        if (changedProperties.has("property")) {
+            const property = changedProperties.get("property") as Property;
+            if (property) {
+                property.off("value", this.onUpdate, this);
+            }
+            if (this.property) {
+                this.property.on("value", this.onUpdate, this);
+            }
+        }
+
+        super.update(changedProperties);
+    }
+
+    protected render()
+    {
+        const property = this.property;
+        const schema = property.schema;
+        const name = this.name || property.name;
+        const min = schema.min;
+        const max = schema.max;
+        const bounded = isFinite(min) && isFinite(max);
+        const value = this.value;
+        let text :string;
+        
+        if(!isFinite(value)){
+            text = value > 0 ? "inf" : "-inf";
+        }else{
+            const precision = schema.precision !== undefined
+            ? schema.precision : PropertyField.defaultPrecision;
+
+            if (schema.percent) {
+                text = (value * 100).toFixed(precision - 2);
+            } else {
+                text = value.toFixed(precision);
+            }
+
+        }
+
+        return html`
+            <label class="ff-label ff-off">${name}</label>
+            <div class="sv-property-field">
+                ${bounded? html`<span class="ff-off ff-bar" style="width:${ 100*(value - min) / (max - min)}%;"></span>`:null}
+                <input class="ff-input"
+                    type="text"
+                    pattern="[+\\-]?([0-9.]+|inf)${schema.percent ? "%?" : ""}"
+                    step=${schema.step ?? ""}
+                    min=${min ?? ""}
+                    max=${max ?? ""}
+                    value=${text}
+                    @change=${this.onChange}
+                    @focus=${(e)=>{ e.target.select();}}}
+                    @keypress=${(e)=>{if(e.key === "Enter"){e.target.blur();}}}
+                >
+                ${schema.percent ? html`<span class="ff-off ff-unit">%</span>` : null}
+            </div>
+        `;
+    }
+
+    protected setValue(value: number){
+        if(typeof this.index === "number" && 0 <= this.index){
+            this.property.value[this.index] = value;
+            this.property.set();
+        }else{
+            this.property.setValue(value);
+        }
+    }
+
+    protected onChange = (event: Event) => {
+        let text = (event.target as HTMLInputElement).value;
+
+        if (text.toLowerCase().indexOf("inf") >= 0) {
+            this.setValue(text[0] === "-" ? -Infinity : Infinity);
+            return;
+        }
+        let value :number;
+        if(this.property.schema.percent && text.endsWith("%")){
+            value = +text.slice(0, -1) /100;
+        }else{
+            value = parseFloat(text);
+        }
+
+        this.setValue(value);
+    }
+
+
+
+    protected onPointerDown = (event: PointerEvent)=>{
+        if (!event.isPrimary || event.button !== 0) {
+            return;
+        }
+        if(!isFinite(this.value)){
+            return; //No point in incrementing +/-infinity.
+        }
+        const target = event.target as HTMLInputElement;
+        if((target.tagName !== "INPUT" && !target.classList.contains("sv-property-field")) || target == document.activeElement) return;
+
+        event.preventDefault();
+        this.delta = 0;
+        this.setPointerCapture(event.pointerId);
+        this.addEventListener("pointermove", this.onPointerMove);
+    }
+
+    protected onPointerMove(event: PointerEvent)
+    {
+        event.stopPropagation();
+        event.preventDefault();
+        if(this.delta < 3){
+            this.delta += Math.abs(event.movementX) + Math.abs(event.movementY);
+            return;
+        }
+
+        const property = this.property;
+        const schema = property.schema;
+        let speed = PropertyField.defaultSpeed;
+        if (schema.speed) {
+            speed = schema.speed;
+        } else if (schema.min !== undefined && schema.max !== undefined) {
+            speed = (schema.max - schema.min) / this.clientWidth;
+        }
+
+        speed = event.ctrlKey ? speed * 0.1 : speed;
+        speed = event.shiftKey ? speed * 10 : speed;
+        let value = (this.value + event.movementX * speed);
+
+        value = schema.step !== undefined ? Math.trunc(value / schema.step) * schema.step : value;
+
+        value = schema.min !== undefined ? Math.max(value, schema.min) : value;
+        value = schema.max !== undefined ? Math.min(value, schema.max) : value;
+
+        const precision = schema.precision !== undefined
+                            ? schema.precision : PropertyField.defaultPrecision;
+        value = +value.toFixed(precision);
+
+
+        this.setValue(value);
+    }
+
+    protected onPointerUp(event: PointerEvent)
+    {
+        if(!isFinite(this.delta)) return;
+        this.removeEventListener("pointermove", this.onPointerMove);
+        this.releasePointerCapture(event.pointerId);
+        if(this.delta < 3){
+            console.log("Focus");
+            this.querySelector("input").focus();
+        }
+        this.delta = undefined;
+    }
+}

--- a/source/client/ui/PropertyOptions.ts
+++ b/source/client/ui/PropertyOptions.ts
@@ -42,9 +42,12 @@ export default class PropertyOptions extends CustomElement
     @property({ attribute: false })
     language: CVLanguageManager = null;
 
+    @property({type: Boolean, reflect: true})
+    dropdown :boolean = false;
+
     protected firstConnected()
     {
-        this.classList.add("sv-property-view", "sv-property-options");
+        this.classList.add("sv-property", "sv-property-options");
     }
 
     protected update(changedProperties: PropertyValues): void
@@ -69,8 +72,43 @@ export default class PropertyOptions extends CustomElement
 
         super.update(changedProperties);
     }
-
     protected render()
+    {
+        if(this.dropdown){
+            return this.renderDropdown();
+        }else{
+            return this.renderButtons();
+        }
+    }
+
+    protected renderDropdown(){
+        const property = this.property;
+        const indexMap = this.indexMap;
+        const name = this.name || property.name;
+        const options = this.options || property.schema.options;
+        const value = property.value;
+        const language = this.language;
+
+        let optionsList;
+        if (indexMap) {
+            optionsList = indexMap.map(index =>
+                html`<option value=${index} ?selected=${index === value}>${language ? language.getLocalizedString(options[index]) : options[index]}</option>`);
+        }
+        else {
+            optionsList = options.map((option, index) =>
+                html`<option value=${index} ?selected=${index === value}>${language ? language.getLocalizedString(option) : option}</option>`)
+        }
+
+        return html`
+            <label class="ff-label ff-off">${name}</label>
+            <select class="sv-property-field" @change=${(e)=>this.property.setValue(e.target.value)}>
+                ${optionsList}
+            </select>
+        `;
+    }
+
+
+    protected renderButtons()
     {
         const property = this.property;
         const indexMap = this.indexMap;

--- a/source/client/ui/PropertySlider.ts
+++ b/source/client/ui/PropertySlider.ts
@@ -42,7 +42,7 @@ export default class PropertySlider extends CustomElement
     protected firstConnected()
     {
         super.firstConnected();
-        this.classList.add("sv-property-view", "sv-property-slider");
+        this.classList.add("sv-property", "sv-property-slider");
     }
 
     protected update(changedProperties: PropertyValues): void

--- a/source/client/ui/PropertyString.ts
+++ b/source/client/ui/PropertyString.ts
@@ -33,9 +33,9 @@ export default class PropertyString extends CustomElement
 
     protected firstConnected()
     {
-        this.classList.add("sv-property-view", "sv-property-string");
+        this.classList.add("sv-property", "sv-property-string");
     }
-
+    
     protected update(changedProperties: PropertyValues): void
     {
         if (!this.property) {
@@ -59,13 +59,24 @@ export default class PropertyString extends CustomElement
         super.update(changedProperties);
     }
 
+    protected onChange = (event: Event) => {
+        const value = (event.target as HTMLInputElement).value;
+        this.property.setValue(value);
+    }
+
     protected render()
     {
         const property = this.property;
         const name = this.name || property.name;
         const text = property.value;
 
-        return html`<label class="ff-label ff-off">${name}</label>
-            <div class="ff-string">${text}</div>`;
+        return html`${name? html`<label class="ff-label ff-off">${name}</label>`:null}
+            <input type="text" class="sv-property-field ff-input"
+                value=${text} 
+                @change=${this.onChange}
+                @focus=${(e)=>{ e.target.select();}}}
+                @keypress=${(e)=>{if(e.key === "Enter"){e.target.blur();}}}
+            >
+        `;
     }
 }

--- a/source/client/ui/explorer/styles.scss
+++ b/source/client/ui/explorer/styles.scss
@@ -1200,6 +1200,96 @@ $tour-entry-indent: 12px;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// PROPERTIES
+.sv-property{
+
+
+  .ff-input{
+    min-width: auto;
+    width: 0;
+    margin: 0;
+    padding: 2px;
+  }
+
+  .ff-input, select{
+    text-align: right;
+    &:focus{
+      text-align: left;
+    }
+  }
+
+  &.sv-property-color {
+    input[type="color"] {
+      cursor: pointer;
+      border: none;
+      margin: 2px;
+      height: 26px;
+      inline-size: 26px;
+      padding: 1px;
+      background: $color-background;
+      border-radius: 2px;
+      &::-webkit-color-swatch-wrapper {
+        padding: 0;
+      }
+      &::-webkit-color-swatch, &::-moz-color-swatch {
+        border: none;
+        border-radius: 2px;
+      }
+    }
+  }
+  
+  &.sv-property-number{
+    .sv-property-field{
+      position: relative;
+      touch-action: none;
+      display: inline-flex;
+      .ff-bar{
+        background: $color-background-dark;
+        position: absolute;
+        inset: 0;
+        margin: 0;
+        width: 0;
+        box-sizing: border-box;
+        border: 2px solid $color-background-darker;
+      }
+      .ff-input, .ff-unit{
+        position: relative;
+        touch-action: none;
+      }
+
+      .ff-bar, .ff-unit{
+        pointer-events: none;
+        user-select: none;
+      }
+    }
+  }
+
+
+
+  &.sv-property-slider {
+    flex: 0 2 180px;
+
+    .ff-linear-slider {
+      height: 6px;
+      margin: 12px 2px;
+      padding-right: 16px;
+      border-radius: 2px;
+      background-color: $color-background-light;
+
+      .ff-knob {
+        width: 16px;
+        height: 26px;
+        margin: -10px 0 0 0;
+        border-radius: 2px;
+        background-color: $color-primary;
+        box-shadow: 0 0 6px black;
+      }
+    }
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 // TOOL BAR
 
 .sv-tool-bar {
@@ -1251,7 +1341,7 @@ $tour-entry-indent: 12px;
   align-items: center;
   font-size: 0.882em;
 
-  .sv-property-view {
+  .sv-property {
     flex: 0 1 auto;
     align-self: start;
     display: flex;
@@ -1267,43 +1357,7 @@ $tour-entry-indent: 12px;
     }
   }
 
-  .sv-property-slider {
-    flex: 0 2 180px;
 
-    .ff-linear-slider {
-      height: 6px;
-      margin: 12px 2px;
-      padding-right: 16px;
-      border-radius: 2px;
-      background-color: $color-background-light;
-
-      .ff-knob {
-        width: 16px;
-        height: 26px;
-        margin: -10px 0 0 0;
-        border-radius: 2px;
-        background-color: $color-primary;
-        box-shadow: 0 0 6px black;
-      }
-    }
-  }
-
-  .sv-property-color {
-
-    & > .ff-button {
-      width: 28px;
-      box-sizing: border-box;
-      border: 1px solid $color-background;
-    }
-
-    .ff-color-edit {
-      position: absolute;
-      width: 200px;
-      height: 180px;
-      right: 8px;
-      top: -188px;
-    }
-  }
 
   .sv-options {
     display: flex;

--- a/source/client/ui/story/PropertyView.ts
+++ b/source/client/ui/story/PropertyView.ts
@@ -15,11 +15,22 @@
  * limitations under the License.
  */
 
+import Color from "@ff/core/Color";
 import Property from "@ff/graph/Property";
 
 import "@ff/scene/ui/PropertyField";
+import "@ff/ui/ColorButton";
+import { IColorEditChangeEvent } from "@ff/ui/ColorButton";
 
 import CustomElement, { customElement, property, html } from "@ff/ui/CustomElement";
+
+import "../PropertyColor";
+import "../PropertyBoolean";
+import "../PropertyString";
+import "../PropertySlider";
+import "../PropertyNumber";
+import "../PropertyOptions";
+import "../PropertyEvent";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -34,8 +45,6 @@ export default class PropertyView extends CustomElement
     @property()
     label: string = undefined;
 
-    @property({ type: Boolean })
-    showLabel = true;
 
     @property({ type: Boolean })
     commitonly = false;
@@ -52,35 +61,39 @@ export default class PropertyView extends CustomElement
     protected render()
     {
         const property = this.property;
+        const schema = property.schema;
         const label = this.label !== undefined ? this.label : property.path.split(".").pop();
-        const showLabel = this.showLabel;
-        const headerElement = showLabel ? html`<div class="sv-property-name">${label}</div>` : null;
 
-        if (property.isArray()) {
-            if (property.elementCount > 4) {
-                return;
-            }
-
-            let fields = [];
-            for (let i = 0; i < property.elementCount; ++i) {
-                fields.push(this.renderField(i));
-            }
-            return html`${headerElement}<div class="sv-property-value">${fields}</div>`;
+        if(property.isArray() && property.type !== "number"){
+            console.error("Unsupported property : ", property);
+            return null;
         }
 
-        return html`${headerElement}<div class="sv-property-value">${this.renderField(-1)}</div>`;
+        if(property.type === "number" && property.schema.semantic === "color"){
+            return html`<sv-property-color name=${label} .property=${property}></sv-property-color>`;
+        }else if (property.type === "number" && property.isArray()) {
+            let fields = [];
+            for (let i = 0; i < property.elementCount; ++i) {
+                const fieldLabel = property.schema.labels?.[i] ?? _defaultLabels[i];
+                fields.push(html`<sv-property-number name=${fieldLabel} .index=${i} .property=${property}></sv-property-number>`);
+            }
+            const headerElement = label ? html`<div class="sv-property-name">${label}</div>` : null;
+            return html`${headerElement}<div class="sv-property-group">${fields}</div>`;
+        }else if (schema.event) {
+            return html`<sv-property-event name=${label} .property=${property}></sv-property-event>`;
+        }else if (schema.options) {
+            return html`<sv-property-options dropdown name=${label} .property=${property}></sv-property-options>`;
+        }else if(property.type === "boolean"){
+            return html`<sv-property-boolean name=${label} .property=${property}></sv-property-boolean>`;
+        }else if(property.type === "string"){
+            return html`<sv-property-string name=${label} .property=${property}></sv-property-string>`
+        }else if(property.type === "number"){
+            return html`<sv-property-number name=${label} .property=${property}></sv-property-number>`
+        }else{
+            console.warn("Unhandled property :", property.name);
+            return html`<div class="sv-property-name">${label}</div><div class="sv-property-group">${property.value} (not editable)</div>`;
+        }
+
     }
 
-    protected renderField(index: number)
-    {
-        const property = this.property;
-        const labels = property.schema.labels || _defaultLabels;
-        const labelElement = index >= 0 ? html`<div class="sv-field-label">${labels[index]}</div>` : null;
-        const commitOnly = this.commitonly;
-
-        return html`<div class="ff-flex-row sv-field-row">
-            ${labelElement}
-            <ff-property-field .property=${property} .index=${index} ?commitonly=${commitOnly}></ff-property-field>
-        </div>`;
-    }
 }

--- a/source/client/ui/story/SettingsTaskView.ts
+++ b/source/client/ui/story/SettingsTaskView.ts
@@ -90,12 +90,12 @@ export class SettingsTree extends Tree<ITreeNode>
 
     protected renderNodeHeader(node: ITreeNode)
     {
-        if (node.property) {
-            return html`<div class="ff-text ff-property-label ff-ellipsis">${node.text}</div>
-                <ff-property-view .property=${node.property}></ff-property-view>`;
+        if (!node.property) {
+            return html`<div class="ff-text ff-label ff-ellipsis">${node.text}</div>`;
         }
 
-        return html`<div class="ff-text ff-label ff-ellipsis">${node.text}</div>`;
+        return html`<sv-property-view .property=${node.property}></sv-property-view>`;
+
     }
 
     protected createNodeTreeNode(node: Node): ITreeNode

--- a/source/client/ui/story/styles.scss
+++ b/source/client/ui/story/styles.scss
@@ -334,6 +334,7 @@ $color-component-meta-light: #d9d998;
 // TASK VIEW
 
 .sv-task-view {
+  container-type: size;
   @include fullsize;
   display: flex;
   flex-direction: column;
@@ -401,43 +402,79 @@ $color-component-meta-light: #d9d998;
 // PROPERTY VIEW
 
 .sv-property-view {
-  flex: 0 0 auto;
+  flex-grow: 1;
+  max-width: 100%;
   display: flex;
   margin: 2px 0;
-  
+
   * {
     box-sizing: content-box;
   }
 
   .sv-property-name {
-    flex: 1 1 25%;
+    flex: 0 1 25%;
     padding-top: 4px;
     color: $color-text-dark;
   }
 
-  .sv-property-value {
-    flex: 1 1 75%;
-    @include ellipsis;
-  }
-
-  .sv-field-row {
-    margin: 4px 0;
-  }
-  .sv-field-label {
-    flex: 0 0 auto;
-    margin: 0 8px 0 0;
-    color: $color-icon;
-  }
-  .ff-property-field {
-    height: 1em;
-    flex: 1 1 auto;
-    padding: 2px;
-    background-color: $color-background-darker;
-
-    input {
-      padding: 2px;
-      background-color: $color-background-darker;
+  .sv-property{
+    display: flex;
+    flex-grow: 1;
+    justify-content: space-between;
+    .ff-label{
+      padding: 0 2px;
+      align-self: center;
     }
+
+    .ff-button.ff-control{
+      display: block;
+      margin: 2px;
+      padding: 0 5px;
+      line-height: 1.35;
+    }
+
+
+    .sv-property-field {
+      background-color: $color-background-darker;
+      flex: 1 1 auto;
+      min-width: auto;
+      max-width: 20ch;
+      line-height: 1.35;
+      margin: 2px;
+      padding: 2px;
+
+      color: inherit;
+      border: none;
+
+      .ff-input{
+        box-sizing: border-box;
+        width: 100%;
+        background: none;
+      }
+    }
+  }
+
+
+  .sv-property-group {
+    /* for properties that are an array of values*/
+    flex-grow: 1;
+    max-width: 75%;
+    display: flex;
+    flex-wrap: wrap;
+    .sv-property{
+      justify-content: flex-end;
+      margin-left: 4px;
+      .sv-property-field{
+        width: 6ch;
+        flex-grow: 1;
+      }
+    }
+  }
+}
+
+@container (width < 350px){
+  .sv-property-view .sv-property-group{
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION

So, following up on #257 was something of a rabbit hole.

**TL:DR:** Those changes removes ~1000 lines of hard-to-maintain code while providing the following :

 - Hex/HSV/RGB color notation support for color selection, working everywhere (native color picker)
 - all-or-nothing wrap for groups of number (uses `@container` when available, gracefully degrade to an ugly wrap otherwise)
 - uniform styling across Explorer/Story applications for input colors and styles
 - clear visual indicator for boolean properties or options properties.

**Long version :**

Turns out there were (kind of) 3 systems, none of them working in every case:

 - `<ff-property-view>` : general purpose custom built do-it-all input component for `voyager-story`
 - `<sv-property-view>` : more limited version of the former. Uses the same `<ff-property-field>` internally.
 - `<sv-property-*>` : specialized property editors, used in `voyager-explorer`
 
It felt like a good opportunity to delete (stop using, really: Can't delete across submodules.) a good thousand lines of code. The main reasoning here is [PropertyField](https://github.com/Smithsonian/ff-scene/blob/master/source/ui/PropertyField.ts) is too hard to read and tries to do too much using very specific code where native components do (mostly) what we want in many cases.

Where possible, custom components were replaced by their native counterparts. In particular:

 - native color swatch instead of the custom one
 - use HTMLInputElement with styles and additional bindings as required, instead of custom div elements

It allows native support of things previously handled by internal code (less code, possible quality improvement):

 - Hex/HSV/RGB color notation support (provided by native color swatch)
 - "Tab" to switch to next input (auto-handled by inputs)
 - proper select options and color swatch scaling on every devices (using the native components)
 
 
I added some binding code to those elements to preserve useful features from the current implementation :

 - "Enter" to blur inputs
 - Drag to edit numeric values
 - "fill" indicator for bounded numeric values
 - +/- infinity support for number inputs


Due to the higher specificity of components, this code is generally shorter and easier to identify.

I intentionally removed some things (that can be added back if needed):

- Unused properties on the `sv-property-*` components to try to have a clean base.
- Numeric 0..1 RGB input for colors. If we are to add something alongside the color swatch, my vote is for hex notation.


All in all, I think it's a better starting point for any UI changes we might want to do in the future than the existing system.


I tested I much as I could, on desktop Chrome/Firefox and iOS safari, everything should work as well/better than before!

