### PR TITLE
set max-width to 100% and height to auto

### DIFF
--- a/source/client/ui/story/ArticleEditor.ts
+++ b/source/client/ui/story/ArticleEditor.ts
@@ -38,6 +38,7 @@ import 'tinymce/plugins/media';
 /* Import content css */
 import contentUiCss from '!!raw-loader!./editor_css/content.ui.min.css';
 import contentCss from '!!raw-loader!./editor_css/content.min.css';
+import contentOverrides from '!!raw-loader!./editor_css/overrides.css';
 
 import Notification from "@ff/ui/Notification";
 import MessageBox from "@ff/ui/MessageBox";
@@ -214,7 +215,7 @@ export default class ArticleEditor extends SystemView
             link_assume_external_targets: 'https',
             paste_as_text: true,
             content_css: false,
-            content_style: [contentCss, contentUiCss].join('\n'),
+            content_style: [contentCss, contentUiCss, contentOverrides].join('\n'),
             convert_urls: false,
             image_caption: true,
             link_default_target: '_blank',

--- a/source/client/ui/story/editor_css/overrides.css
+++ b/source/client/ui/story/editor_css/overrides.css
@@ -1,0 +1,7 @@
+/*
+ * CSS Rules overrides over tinymce's default styles
+ */
+.mce-content-body img {
+  max-width: 100%;
+  height: auto;
+}

--- a/source/client/ui/styles.scss
+++ b/source/client/ui/styles.scss
@@ -81,6 +81,7 @@
 
   img {
     max-width: 100%;
+    height: auto;
   }
 
   figure {


### PR DESCRIPTION
`max-width` was already set in [styles.scss#L83](https://github.com/Smithsonian/dpo-voyager/blob/master/source/client/ui/styles.scss#L83), but not in editor leading to inconsistent behaviour.

Moreover, max-width without `height: auto` leads to stretched images.

I created a new css file because the current `content.ui.min.css`and `content.min.css` seems directly imported from tinyMCE and keeping them pristine will probably help future updates.

With those changes it is still possible to manually force images to stretch by specifying a different `height` in the image block popup.
