### PR TITLE
grammatical correction from Deutsche to Deutsch

### DIFF
--- a/source/client/schema/common.ts
+++ b/source/client/schema/common.ts
@@ -30,7 +30,7 @@ export enum ELanguageType { EN, ES, DE, NL, JA, FR, HAW }
 export enum ELanguageStringType {
     EN = 'English',
     ES = 'Spanish (Español)',
-    DE = 'German (Deutsche)',
+    DE = 'German (Deutsch)',
     NL = 'Dutch (Nederlands)',
     JA = 'Japanese (日本語)',
     FR = 'French (Français)',


### PR DESCRIPTION
A German colleague pointed out a small grammatical error for the ui pop-up to switch to the german language version of her voyager. It should be German (Deutsch) instead of German (Deutsche). I will also ask her to update the german language interface accessibility.  