### PR TITLE
Better other default language support

### DIFF
--- a/source/client/components/CVAnnotationView.ts
+++ b/source/client/components/CVAnnotationView.ts
@@ -438,7 +438,12 @@ export default class CVAnnotationView extends CObject3D
 
     fromData(data: IAnnotation[])
     {
-        data.forEach(annotationJson => this.addAnnotation(new Annotation(annotationJson)));
+        const language = this.language.outs.language.value;
+        data.forEach(annotationJson => {
+            let a = new Annotation(annotationJson);
+            a.language = language;
+            this.addAnnotation(a);
+        });
         this.emit<ITagUpdateEvent>({ type: "tag-update" });
     }
 

--- a/source/client/components/CVAnnotationsTask.ts
+++ b/source/client/components/CVAnnotationsTask.ts
@@ -57,13 +57,13 @@ export default class CVAnnotationsTask extends CVTask
 
     protected static readonly ins = {
         mode: types.Enum("Mode", EAnnotationsTaskMode, EAnnotationsTaskMode.Off),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType.EN]),
+        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
         audio: types.Option("Annotation.Audio", ["None"], 0),
         selection: types.Event("Annotation.Selection")
     };
 
     protected static readonly outs = {
-        language: types.Enum("Interface.Language", ELanguageType, ELanguageType.EN),
+        language: types.Enum("Interface.Language", ELanguageType, ELanguageType[DEFAULT_LANGUAGE]),
     };
 
     ins = this.addInputs<CVTask, typeof CVAnnotationsTask.ins>(CVAnnotationsTask.ins);

--- a/source/client/components/CVAnnotationsTask.ts
+++ b/source/client/components/CVAnnotationsTask.ts
@@ -57,17 +57,12 @@ export default class CVAnnotationsTask extends CVTask
 
     protected static readonly ins = {
         mode: types.Enum("Mode", EAnnotationsTaskMode, EAnnotationsTaskMode.Off),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
         audio: types.Option("Annotation.Audio", ["None"], 0),
         selection: types.Event("Annotation.Selection")
     };
 
-    protected static readonly outs = {
-        language: types.Enum("Interface.Language", ELanguageType, ELanguageType[DEFAULT_LANGUAGE]),
-    };
 
     ins = this.addInputs<CVTask, typeof CVAnnotationsTask.ins>(CVAnnotationsTask.ins);
-    outs = this.addOutputs<CVTask, typeof CVAnnotationsTask.outs>(CVAnnotationsTask.outs);
 
     private _activeAnnotations: CVAnnotationView = null;
     private _defaultScale = 1;
@@ -104,7 +99,6 @@ export default class CVAnnotationsTask extends CVTask
     {
         this.startObserving();
         super.activateTask();
-        this.synchLanguage();
         this.synchAudioOptions();
 
         //this.selection.selectedComponents.on(CVAnnotationView, this.onSelectAnnotations, this);
@@ -133,15 +127,6 @@ export default class CVAnnotationsTask extends CVTask
             this.emitUpdateEvent();
         }
 
-        if(ins.language.changed) {   
-            const newLanguage = ELanguageType[ELanguageType[ins.language.value]];
-
-            languageManager.addLanguage(newLanguage);  // add in case this is a currently inactive language
-            languageManager.ins.language.setValue(newLanguage);
-            outs.language.setValue(newLanguage);
-            return true;
-        }
-
         if(ins.audio.changed) {
             const audioManager = this.activeDocument.setup.audio;
             const id = ins.audio.value > 0 ? audioManager.getAudioList()[ins.audio.value - 1].id : "";
@@ -157,8 +142,6 @@ export default class CVAnnotationsTask extends CVTask
         if(ins.selection.changed) {
             this.setAudio();
         }
-
-        this.synchLanguage();
 
         return true;
     }
@@ -377,17 +360,6 @@ export default class CVAnnotationsTask extends CVTask
         const textboxes = document.getElementsByClassName("ff-text-edit");
         for(let box of textboxes) {
             (box as HTMLElement).blur();
-        }
-    }
-
-    // Make sure this task language matches document
-    protected synchLanguage() {
-        const {ins} = this;
-        const languageManager = this.activeDocument.setup.language;
-
-        if(ins.language.value !== languageManager.outs.language.value)
-        {
-            ins.language.setValue(languageManager.outs.language.value, true);
         }
     }
 

--- a/source/client/components/CVArticlesTask.ts
+++ b/source/client/components/CVArticlesTask.ts
@@ -58,7 +58,7 @@ export default class CVArticlesTask extends CVTask
         lead: types.String("Article.Lead"),
         tags: types.String("Article.Tags"),
         uri: types.String("Article.URI"),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType.EN]),
+        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
     };
 
     protected static readonly outs = {

--- a/source/client/components/CVArticlesTask.ts
+++ b/source/client/components/CVArticlesTask.ts
@@ -58,7 +58,6 @@ export default class CVArticlesTask extends CVTask
         lead: types.String("Article.Lead"),
         tags: types.String("Article.Tags"),
         uri: types.String("Article.URI"),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
     };
 
     protected static readonly outs = {
@@ -98,7 +97,6 @@ export default class CVArticlesTask extends CVTask
     {
         this.startObserving();
         super.activateTask();
-        this.synchLanguage();
     }
 
     deactivateTask()
@@ -121,13 +119,6 @@ export default class CVArticlesTask extends CVTask
             return false;
         }
         const languageManager = this.activeDocument.setup.language;
-
-        if(ins.language.changed) {   
-            const newLanguage = ELanguageType[ELanguageType[ins.language.value]];
-
-            languageManager.addLanguage(newLanguage);  // add in case this is a currently inactive language
-            languageManager.ins.language.setValue(newLanguage);
-        }
 
         if (meta && ins.create.changed) {
             const article = new Article();
@@ -309,6 +300,7 @@ export default class CVArticlesTask extends CVTask
         const ins = this.ins;
         const outs = this.outs;
         const meta = this.meta;
+        const languageManager = this.activeDocument.setup.language;
         let article = this.reader.activeArticle;
 
         if (meta && article && meta.articles.getById(article.id)) {
@@ -320,7 +312,7 @@ export default class CVArticlesTask extends CVTask
             // if we don't have a uri for this language, create one so that it is editable
             if(article.uri === undefined) {
                 const defaultFolder = CVMediaManager.articleFolder;
-                article.uri = `${defaultFolder}/new-article-${article.id}-${ELanguageType[ins.language.value]}.html`;
+                article.uri = `${defaultFolder}/new-article-${article.id}-${ELanguageType[languageManager.ins.language.value]}.html`;
                 this.ins.version.set();
             }
             else {
@@ -344,20 +336,9 @@ export default class CVArticlesTask extends CVTask
         const article = this.activeArticle;
         const {ins} = this;
 
-        this.synchLanguage();
         this.onArticleChange();
     }
 
-    // Make sure this task language matches document
-    protected synchLanguage() {
-        const {ins} = this;
-        const languageManager = this.activeDocument.setup.language;
-
-        if(ins.language.value !== languageManager.outs.language.value)
-        {
-            ins.language.setValue(languageManager.outs.language.value, true);
-        }
-    }
 
     // Handle potential media manager name change
     protected onAssetRename(event: IAssetRenameEvent) {

--- a/source/client/components/CVArticlesTask.ts
+++ b/source/client/components/CVArticlesTask.ts
@@ -312,7 +312,7 @@ export default class CVArticlesTask extends CVTask
             // if we don't have a uri for this language, create one so that it is editable
             if(article.uri === undefined) {
                 const defaultFolder = CVMediaManager.articleFolder;
-                article.uri = `${defaultFolder}/new-article-${article.id}-${ELanguageType[languageManager.ins.language.value]}.html`;
+                article.uri = `${defaultFolder}/new-article-${article.id}-${languageManager.codeString()}.html`;
                 this.ins.version.set();
             }
             else {

--- a/source/client/components/CVAudioTask.ts
+++ b/source/client/components/CVAudioTask.ts
@@ -100,7 +100,7 @@ export default class CVAudioTask extends CVTask
 
         const clip = audioManager.getAudioClip(ins.activeId.value);
         const languageManager = this.activeDocument.setup.language;
-        const activeLanguage = languageManager.ins.language.value;
+        const activeLanguage = languageManager.codeString();
 
         if (ins.create.changed) {
             const newId = Document.generateId();
@@ -129,8 +129,8 @@ export default class CVAudioTask extends CVTask
 
         if (clip && (ins.title.changed || ins.filepath.changed || ins.captionPath.changed)) {
             clip.name = ins.title.value;
-            clip.uris[ELanguageType[activeLanguage]] = ins.filepath.value;
-            clip.captionUris[ELanguageType[activeLanguage]] = ins.captionPath.value;
+            clip.uris[activeLanguage] = ins.filepath.value;
+            clip.captionUris[activeLanguage] = ins.captionPath.value;
             audioManager.updateAudioClip(clip.id);
         }
         if (ins.isNarration.changed) {
@@ -164,11 +164,11 @@ export default class CVAudioTask extends CVTask
         const audioManager = this.audioManager;
         const clip = audioManager.getAudioClip(ins.activeId.value);
         const languageManager = this.activeDocument.setup.language;
-        const activeLanguage = languageManager.ins.language.value;
+        const activeLanguage = languageManager.codeString();
 
         ins.title.setValue(clip ? clip.name : "", true);
-        ins.filepath.setValue(clip ? clip.uris[ELanguageType[activeLanguage]] : "", true);
-        ins.captionPath.setValue(clip ? clip.captionUris[ELanguageType[activeLanguage]] : "", true);
+        ins.filepath.setValue(clip ? clip.uris[activeLanguage] : "", true);
+        ins.captionPath.setValue(clip ? clip.captionUris[activeLanguage] : "", true);
         ins.isNarration.setValue(clip ? this.audioManager.narrationId === clip.id : false, true);
     }
 

--- a/source/client/components/CVAudioTask.ts
+++ b/source/client/components/CVAudioTask.ts
@@ -23,7 +23,7 @@ import AudioTaskView from "../ui/story/AudioTaskView";
 import { Node } from "@ff/graph/Component";
 import CVDocument from "./CVDocument";
 import CVAudioManager from "./CVAudioManager";
-import { ELanguageStringType, ELanguageType } from "client/schema/common";
+import { DEFAULT_LANGUAGE, ELanguageStringType, ELanguageType } from "client/schema/common";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -44,7 +44,7 @@ export default class CVAudioTask extends CVTask
         filepath: types.String("Audio.Filepath", null),
         captionPath: types.String("Audio.CaptionPath", null),
         isNarration: types.Boolean("Audio.IsNarration", false),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType.EN]),
+        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
     };
 
     protected static readonly outs = {

--- a/source/client/components/CVLanguageManager.ts
+++ b/source/client/components/CVLanguageManager.ts
@@ -46,11 +46,12 @@ export default class CVLanguageManager extends Component
 
     protected static readonly ins = {
         enabled: types.Boolean("Language.Enabled", false),
-        language: types.Enum("Interface.Language", ELanguageType, ELanguageType.EN),
+        language: types.Enum("Interface.Language", ELanguageType, ELanguageType[DEFAULT_LANGUAGE]),
     };
 
     protected static readonly outs = {
-        language: types.Enum("Interface.Language", ELanguageType, ELanguageType.EN),
+        /* exception to default language: in absence of any dictionary, this is always EN */
+        language: types.Enum("Interface.Language", ELanguageType, ELanguageType.EN ),
     };
 
     ins = this.addInputs(CVLanguageManager.ins);
@@ -114,7 +115,7 @@ export default class CVLanguageManager extends Component
         const language = ELanguageType[data.language || "EN"];
 
         if(language != outs.language.value && ins.language.value === outs.language.value) {
-            ins.language.setValue(isFinite(language) ? language : ELanguageType.EN);
+            ins.language.setValue(isFinite(language) ? language : ELanguageType[DEFAULT_LANGUAGE]);
         }
     }
 

--- a/source/client/components/CVLanguageManager.ts
+++ b/source/client/components/CVLanguageManager.ts
@@ -75,7 +75,11 @@ export default class CVLanguageManager extends Component
         return this._activeLanguages;
     }
 
-    nameString()
+    /**
+     * 
+     * @returns Full text string of the currently selected language
+     */
+    nameString() :string
     {
         return ELanguageStringType[ELanguageType[this.ins.language.value]];
     }

--- a/source/client/components/CVLanguageManager.ts
+++ b/source/client/components/CVLanguageManager.ts
@@ -20,6 +20,7 @@ import { ILanguage, ILanguageOption } from "client/schema/setup";
 import { ELanguageType, TLanguageType, ELanguageStringType, DEFAULT_LANGUAGE } from "client/schema/common";
 import CVAssetReader from "./CVAssetReader";
 import { ITagUpdateEvent } from "./CVModel2";
+import { enumToArray } from "@ff/core/types";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -46,7 +47,11 @@ export default class CVLanguageManager extends Component
 
     protected static readonly ins = {
         enabled: types.Boolean("Language.Enabled", false),
-        language: types.Enum("Interface.Language", ELanguageType, ELanguageType[DEFAULT_LANGUAGE]),
+        language: types.Enum("Interface.Language", ELanguageType, {
+            preset: ELanguageType[DEFAULT_LANGUAGE],
+            enum: ELanguageType,
+            options: enumToArray(ELanguageStringType).map(key => ELanguageStringType[key])
+        }),
     };
 
     protected static readonly outs = {

--- a/source/client/components/CVMeta.ts
+++ b/source/client/components/CVMeta.ts
@@ -59,6 +59,9 @@ export default class CVMeta extends Component
 
         if (data.collection) {
             this.collection.dictionary = data.collection;
+            Object.keys(this.collection.get("titles")).forEach( key => {
+                this.language.addLanguage(ELanguageType[key]);
+            });
         }
         if (data.process) {
             this.process.dictionary = data.process;

--- a/source/client/components/CVTaskProvider.ts
+++ b/source/client/components/CVTaskProvider.ts
@@ -47,7 +47,6 @@ export default class CVTaskProvider extends CComponentProvider<CVTask>
 
     protected static readonly ins = {
         mode: types.Enum("Tasks.Mode", ETaskMode),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
     };
 
     ins = this.addInputs(CVTaskProvider.ins);
@@ -76,15 +75,6 @@ export default class CVTaskProvider extends CComponentProvider<CVTask>
 
             const taskSet = taskSets[ins.mode.getValidatedValue()];
             taskSet.forEach(taskType => this.createComponent(taskType));
-        }
-
-        if(ins.language.changed) {   
-            const newLanguage = ELanguageType[ELanguageType[ins.language.value]];
-
-            if(languageManager) {
-                languageManager.addLanguage(newLanguage);  // add in case this is a currently inactive language
-                languageManager.ins.language.setValue(newLanguage);
-            }
         }
 
         return true;

--- a/source/client/components/CVTaskProvider.ts
+++ b/source/client/components/CVTaskProvider.ts
@@ -25,7 +25,7 @@ import CComponentProvider, {
 
 import CVTask from "./CVTask";
 import taskSets, { ETaskMode } from "../applications/taskSets";
-import { ELanguageStringType, ELanguageType } from "client/schema/common";
+import { DEFAULT_LANGUAGE, ELanguageStringType, ELanguageType } from "client/schema/common";
 import CVLanguageManager from "./CVLanguageManager";
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -47,7 +47,7 @@ export default class CVTaskProvider extends CComponentProvider<CVTask>
 
     protected static readonly ins = {
         mode: types.Enum("Tasks.Mode", ETaskMode),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType.EN]),
+        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
     };
 
     ins = this.addInputs(CVTaskProvider.ins);

--- a/source/client/components/CVToursTask.ts
+++ b/source/client/components/CVToursTask.ts
@@ -54,7 +54,7 @@ export default class CVToursTask extends CVTask
         stepCurve: types.Enum("Step.Curve", EEasingCurve),
         stepDuration: types.Number("Step.Duration", 1),
         stepThreshold: types.Percent("Step.Threshold", 0.5),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType.EN]),
+        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
     };
 
     protected static readonly outs = {

--- a/source/client/components/CVToursTask.ts
+++ b/source/client/components/CVToursTask.ts
@@ -54,7 +54,6 @@ export default class CVToursTask extends CVTask
         stepCurve: types.Enum("Step.Curve", EEasingCurve),
         stepDuration: types.Number("Step.Duration", 1),
         stepThreshold: types.Percent("Step.Threshold", 0.5),
-        language: types.Option("Task.Language", Object.keys(ELanguageStringType).map(key => ELanguageStringType[key]), ELanguageStringType[ELanguageType[DEFAULT_LANGUAGE]]),
     };
 
     protected static readonly outs = {
@@ -102,13 +101,6 @@ export default class CVToursTask extends CVTask
 
         const languageManager = this.activeDocument.setup.language;
 
-        if(ins.language.changed) {   
-            const newLanguage = ELanguageType[ELanguageType[ins.language.value]];
-
-            languageManager.addLanguage(newLanguage);  // add in case this is a currently inactive language
-            languageManager.ins.language.setValue(newLanguage);
-            //outs.language.setValue(newLanguage);
-        }
 
         if (tour) {
             const stepList = tour.steps;
@@ -232,8 +224,6 @@ export default class CVToursTask extends CVTask
         if (this.tours) {
             this.tours.ins.enabled.setValue(true);
         }
-
-        this.synchLanguage();
     }
 
     deactivateTask()
@@ -305,18 +295,6 @@ export default class CVToursTask extends CVTask
         this.onTourChange();
         this.onStepChange();
         tours.ins.tourIndex.setValue(tours.outs.tourIndex.value);  // trigger UI refresh
-
-        this.synchLanguage();
     }
 
-    // Make sure this task language matches document
-    protected synchLanguage() {
-        const {ins} = this;
-        const languageManager = this.activeDocument.setup.language;
-
-        if(ins.language.value !== languageManager.outs.language.value)
-        {
-            ins.language.setValue(languageManager.outs.language.value, true);
-        }
-    }
 }

--- a/source/client/ui/PropertyOptions.ts
+++ b/source/client/ui/PropertyOptions.ts
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+	
+import {live} from "lit-html/directives/live";
 
 import Property from "@ff/graph/Property";
 import CustomElement, { customElement, property, PropertyValues, html } from "@ff/ui/CustomElement";
@@ -64,6 +66,7 @@ export default class PropertyOptions extends CustomElement
             const property = changedProperties.get("property") as Property;
             if (property) {
                 property.off("value", this.onUpdate, this);
+                property.off("change", this.onUpdate, this);
             }
             if (this.property) {
                 this.property.on("value", this.onUpdate, this);
@@ -102,8 +105,7 @@ export default class PropertyOptions extends CustomElement
 
         return html`
             <label class="ff-label ff-off">${name}</label>
-            <select ?multiple=${property.isMulti()} class="sv-property-field" @change=${(e)=>{
-                console.debug("Select value : ", e.target.value);
+            <select ?multiple=${property.isMulti()} .value=${live(value)} class="sv-property-field" @change=${(e)=>{
                 this.property.setValue(e.target.value)
             }}>
                 ${optionsList}

--- a/source/client/ui/explorer/styles.scss
+++ b/source/client/ui/explorer/styles.scss
@@ -1315,6 +1315,19 @@ $tour-entry-indent: 12px;
       }
     }
   }
+
+  &.sv-property-options{
+    .sv-options-buttons{
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      padding: 2px 0;
+      gap: 2px;
+      .ff-button.ff-control{
+        flex: 0 1 auto;
+      }
+    }
+  }
 }
 
 

--- a/source/client/ui/story/AnnotationsTaskView.ts
+++ b/source/client/ui/story/AnnotationsTaskView.ts
@@ -58,12 +58,12 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
         this.sceneview = explorer.shadowRoot.querySelector(".sv-scene-view") as HTMLElement;
         
         this.task.on("update", this.onUpdate, this);
-        this.task.ins.language.on("value", this.onUpdate, this);
+        this.activeDocument.setup.language.ins.language.on("value", this.onUpdate, this);
     }
 
     protected disconnected()
     {
-        this.task.ins.language.off("value", this.onUpdate, this);
+        this.activeDocument.setup.language.ins.language.off("value", this.onUpdate, this);
         this.task.off("update", this.onUpdate, this);
 
         // set cursor to grab when leaving
@@ -76,6 +76,7 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
     {
         const node = this.activeNode;
         const annotations = node && node.getComponent(CVAnnotationView, true);
+        const languageManager = this.activeDocument.setup.language;
 
         if (!annotations) {
             // set cursor to grab
@@ -118,7 +119,7 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
             ${imagePropView}
             <sv-property-view .property=${audioProp}></sv-property-view>
             <sv-property-view .property=${inProps.marker}></sv-property-view>
-            <sv-property-view .property=${this.task.ins.language}></sv-property-view>
+            <sv-property-view .property=${languageManager.ins.language}></sv-property-view>
             <div class="sv-indent">
                 <sv-property-view .property=${inProps.article}></sv-property-view>
                 <sv-property-view .property=${inProps.tags}></sv-property-view>
@@ -142,7 +143,7 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
         </div>
         <div class="ff-flex-item-stretch">
             <div class="ff-flex-column ff-fullsize">
-                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[this.task.ins.language.value] as TLanguageType]}</div></div>
+                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[languageManager.ins.language.value] as TLanguageType]}</div></div>
                 <div class="ff-splitter-section" style="flex-basis: 30%">
                     <div class="ff-scroll-y ff-flex-column">
                         <sv-annotation-list .data=${annotationList} .selectedItem=${annotation} @select=${this.onSelectAnnotation}></sv-annotation-list>

--- a/source/client/ui/story/AnnotationsTaskView.ts
+++ b/source/client/ui/story/AnnotationsTaskView.ts
@@ -32,7 +32,7 @@ import { ISelectAnnotationEvent } from "./AnnotationList";
 import CVAnnotationView from "../../components/CVAnnotationView";
 import CVAnnotationsTask, { EAnnotationsTaskMode } from "../../components/CVAnnotationsTask";
 import { TaskView } from "../../components/CVTask";
-import { ELanguageStringType, ELanguageType, TLanguageType, DEFAULT_LANGUAGE } from "client/schema/common";
+import { ELanguageStringType, DEFAULT_LANGUAGE } from "client/schema/common";
 
 import sanitizeHtml from 'sanitize-html';
 import CVMediaManager from "client/components/CVMediaManager";
@@ -143,7 +143,7 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
         </div>
         <div class="ff-flex-item-stretch">
             <div class="ff-flex-column ff-fullsize">
-                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[languageManager.ins.language.value] as TLanguageType]}</div></div>
+                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${languageManager.nameString()}</div></div>
                 <div class="ff-splitter-section" style="flex-basis: 30%">
                     <div class="ff-scroll-y ff-flex-column">
                         <sv-annotation-list .data=${annotationList} .selectedItem=${annotation} @select=${this.onSelectAnnotation}></sv-annotation-list>

--- a/source/client/ui/story/ArticlesTaskView.ts
+++ b/source/client/ui/story/ArticlesTaskView.ts
@@ -49,6 +49,7 @@ export default class ArticlesTaskView extends TaskView<CVArticlesTask>
         const task = this.task;
         const articles = task.articles;
         const activeArticle = task.activeArticle;
+        const languageManager = this.activeDocument.setup.language;
 
         if (!articles) {
             return html`<div class="sv-placeholder">Please select a scene or model node to edit its articles.</div>`;
@@ -57,7 +58,7 @@ export default class ArticlesTaskView extends TaskView<CVArticlesTask>
         const props = task.ins;
 
         const detailView = activeArticle ? html`<div class="ff-scroll-y ff-flex-column sv-detail-view">
-            <sv-property-view .property=${this.task.ins.language}></sv-property-view>
+            <sv-property-view .property=${languageManager.ins.language}></sv-property-view>
             <div class="sv-label">Title</div>
             <ff-line-edit name="title" text=${props.title.value} @change=${this.onTextEdit}></ff-line-edit>
             <div class="sv-label">Tags</div>
@@ -81,7 +82,7 @@ export default class ArticlesTaskView extends TaskView<CVArticlesTask>
         </div>
         <div class="ff-flex-item-stretch">
             <div class="ff-flex-column ff-fullsize">
-                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[this.task.ins.language.value] as TLanguageType]}</div></div>
+                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[languageManager.ins.language.value] as TLanguageType]}</div></div>
                 <div class="ff-splitter-section" style="flex-basis: 30%">
                     <div class="ff-scroll-y ff-flex-column">
                         <sv-article-list .data=${articles.slice()} .selectedItem=${activeArticle} @select=${this.onSelectArticle} @edit=${this.onEditArticle}></sv-article-list>

--- a/source/client/ui/story/ArticlesTaskView.ts
+++ b/source/client/ui/story/ArticlesTaskView.ts
@@ -25,7 +25,7 @@ import Article from "../../models/Article";
 
 import CVArticlesTask from "../../components/CVArticlesTask";
 import { TaskView } from "../../components/CVTask";
-import { ELanguageStringType, ELanguageType, TLanguageType, DEFAULT_LANGUAGE } from "client/schema/common";
+import { ELanguageStringType, DEFAULT_LANGUAGE } from "client/schema/common";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -82,7 +82,7 @@ export default class ArticlesTaskView extends TaskView<CVArticlesTask>
         </div>
         <div class="ff-flex-item-stretch">
             <div class="ff-flex-column ff-fullsize">
-                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[languageManager.ins.language.value] as TLanguageType]}</div></div>
+                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${languageManager.nameString()}</div></div>
                 <div class="ff-splitter-section" style="flex-basis: 30%">
                     <div class="ff-scroll-y ff-flex-column">
                         <sv-article-list .data=${articles.slice()} .selectedItem=${activeArticle} @select=${this.onSelectArticle} @edit=${this.onEditArticle}></sv-article-list>

--- a/source/client/ui/story/AudioTaskView.ts
+++ b/source/client/ui/story/AudioTaskView.ts
@@ -62,6 +62,7 @@ export default class AudioTaskView extends TaskView<CVAudioTask>
         }
         
         const ins = this.task.ins;
+        const languageManager = this.activeDocument.setup.language;
 
         const narrationFlagClass = "sv-task-option-base-align";
         const audio = this.task.audioManager;
@@ -71,7 +72,7 @@ export default class AudioTaskView extends TaskView<CVAudioTask>
 
         const detailView = audioElement ? html`<div class="ff-scroll-y ff-flex-column sv-detail-view">
             <sv-property-view .property=${ins.title}></sv-property-view>
-            <sv-property-view .property=${ins.language}></sv-property-view>
+            <sv-property-view .property=${languageManager.ins.language}></sv-property-view>
             <div class="sv-indent">
                 <sv-property-view id="filename" .property=${ins.filepath} @drop=${this.onDropFile} @dragenter=${this.onDragEnter} @dragover=${this.onDragOver} @dragleave=${this.onDragLeave}></sv-property-view>
                 <sv-property-view id="captionfile" .property=${ins.captionPath} @drop=${this.onDropFile} @dragenter=${this.onDragEnter} @dragover=${this.onDragOver} @dragleave=${this.onDragLeave}></sv-property-view>

--- a/source/client/ui/story/CollectionPanel.ts
+++ b/source/client/ui/story/CollectionPanel.ts
@@ -38,18 +38,13 @@ export default class CollectionPanel extends DocumentView
 
     protected render()
     {
-        const taskProvider = this.taskProvider;
         const languageManager = this.activeDocument.setup.language;
-        if(taskProvider.ins.language.value !== languageManager.outs.language.value)
-        {
-            taskProvider.ins.language.setValue(languageManager.outs.language.value, true);
-        }
 
         return html`<div class="sv-panel-header">
                 <ff-icon name="document"></ff-icon>
                 <div class="ff-text">Collection</div>
             </div>
-            <sv-property-view .property=${this.taskProvider.ins.language}></sv-property-view>
+            <sv-property-view .property=${languageManager.ins.language}></sv-property-view>
             <div class="sv-indent">
                 <div class="sv-label">Title</div>
                 <ff-line-edit name="title" text=${this.activeDocument.ins.title.value || "Missing Title"} @change=${this.onTextEdit}></ff-line-edit>

--- a/source/client/ui/story/CollectionPanel.ts
+++ b/source/client/ui/story/CollectionPanel.ts
@@ -40,7 +40,8 @@ export default class CollectionPanel extends DocumentView
     {
         const languageManager = this.activeDocument.setup.language;
 
-        return html`<div class="sv-panel-header">
+        return html`<div class="ff-scroll-y ff-flex-column" style="padding-bottom: 5px">
+            <div class="sv-panel-header">
                 <ff-icon name="document"></ff-icon>
                 <div class="ff-text">Collection</div>
             </div>
@@ -50,7 +51,8 @@ export default class CollectionPanel extends DocumentView
                 <ff-line-edit name="title" text=${this.activeDocument.ins.title.value || "Missing Title"} @change=${this.onTextEdit}></ff-line-edit>
                 <div class="sv-label">Intro</div>
                 <ff-text-edit name="intro" text=${this.activeDocument.ins.intro.value} @change=${this.onTextEdit}></ff-text-edit>
-            </div>`;
+            </div>
+        </div>`;
     }
 
     protected onTextEdit(event: ILineEditChangeEvent)

--- a/source/client/ui/story/TourPanel.ts
+++ b/source/client/ui/story/TourPanel.ts
@@ -123,7 +123,7 @@ export default class TourPanel extends DocumentView
         this.stateTable.rows = tours.activeSteps.map(step => {
             const state = machine.getState(step.id);
             return {
-                title: step.titles[ELanguageType[languageManager.ins.language.value]] || "undefined",
+                title: step.titles[languageManager.codeString()] || "undefined",
                 curve: EEasingCurve[state.curve],
                 duration: state.duration.toFixed(1) + "s",
                 threshold: (state.threshold * 100).toFixed(0) + "%",

--- a/source/client/ui/story/TourPanel.ts
+++ b/source/client/ui/story/TourPanel.ts
@@ -95,6 +95,7 @@ export default class TourPanel extends DocumentView
         const task = this.toursTask;
         const tours = this.tours;
         const machine = tours.snapshots;
+        const languageManager = this.activeDocument.setup.language;
 
         if (!task || !tours.ins.enabled.value) {
             return html`<div class="ff-placeholder">Tour edit task not available.</div>`;
@@ -122,7 +123,7 @@ export default class TourPanel extends DocumentView
         this.stateTable.rows = tours.activeSteps.map(step => {
             const state = machine.getState(step.id);
             return {
-                title: step.titles[ELanguageType[this.toursTask.ins.language.value]] || "undefined",
+                title: step.titles[ELanguageType[languageManager.ins.language.value]] || "undefined",
                 curve: EEasingCurve[state.curve],
                 duration: state.duration.toFixed(1) + "s",
                 threshold: (state.threshold * 100).toFixed(0) + "%",

--- a/source/client/ui/story/ToursTaskView.ts
+++ b/source/client/ui/story/ToursTaskView.ts
@@ -27,7 +27,7 @@ import { ILineEditChangeEvent } from "@ff/ui/LineEdit";
 
 import CVDocument from "../../components/CVDocument";
 import { IButtonClickEvent } from "@ff/ui/Button";
-import { ELanguageType, DEFAULT_LANGUAGE, ELanguageStringType, TLanguageType } from "client/schema/common";
+import { ELanguageType, DEFAULT_LANGUAGE, ELanguageStringType } from "client/schema/common";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -99,7 +99,7 @@ export default class ToursTaskView extends TaskView<CVToursTask>
         </div>
         <div class="ff-flex-item-stretch">
             <div class="ff-flex-column ff-fullsize">
-                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[languageManager.ins.language.value] as TLanguageType]}</div></div>
+                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${languageManager.nameString()}</div></div>
                 <div class="ff-splitter-section" style="flex-basis: 30%">
                     <div class="ff-scroll-y ff-flex-column">
                         <sv-tour-list .data=${tourList.slice()} .selectedItem=${activeTour} .language=${languageManager.ins.language.value} @select=${this.onSelectTour}></sv-tour-list>

--- a/source/client/ui/story/ToursTaskView.ts
+++ b/source/client/ui/story/ToursTaskView.ts
@@ -78,9 +78,10 @@ export default class ToursTaskView extends TaskView<CVToursTask>
         const tourList = tours.tours;
         const activeTour = tours.activeTour;
         const props = task.ins;
+        const languageManager = this.activeDocument.setup.language;
 
         const detailView = activeTour ? html`<div class="ff-scroll-y ff-flex-column sv-detail-view">
-            <sv-property-view .property=${this.task.ins.language}></sv-property-view>
+            <sv-property-view .property=${languageManager.ins.language}></sv-property-view>
             <div class="sv-label">Title</div>
             <ff-line-edit name="title" text=${props.tourTitle.value} @change=${this.onTextEdit}></ff-line-edit>
             <div class="sv-label">Tags</div>
@@ -98,10 +99,10 @@ export default class ToursTaskView extends TaskView<CVToursTask>
         </div>
         <div class="ff-flex-item-stretch">
             <div class="ff-flex-column ff-fullsize">
-                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[this.task.ins.language.value] as TLanguageType]}</div></div>
+                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[ELanguageType[languageManager.ins.language.value] as TLanguageType]}</div></div>
                 <div class="ff-splitter-section" style="flex-basis: 30%">
                     <div class="ff-scroll-y ff-flex-column">
-                        <sv-tour-list .data=${tourList.slice()} .selectedItem=${activeTour} .language=${this.task.ins.language.value} @select=${this.onSelectTour}></sv-tour-list>
+                        <sv-tour-list .data=${tourList.slice()} .selectedItem=${activeTour} .language=${languageManager.ins.language.value} @select=${this.onSelectTour}></sv-tour-list>
                     </div>
                 </div>
                 <ff-splitter direction="vertical"></ff-splitter>


### PR DESCRIPTION
I did a bunch of work trying to bring the multi-language support to a point where non-english speakers and particularly non-primarily-english scenes have a smooth experience.

**There was a number of issues:**

 - In a number of places, `ELanguageType.EN` was used interchangeably with `DEFAULT_LANGUAGE`. The fix is straightforward. `ELanguageType.EN` now used as a default only where it makes sense.
 - I removed every individual task's `ins.language` property. They were the source of a number or race conditions, while barely used in the code and I found it easier to remove them and use `CVLanguageManager`as the unique source of language state everywhere. This should also help avoid regressions in the future.

**Some backward-compatible changes : **

 - Fixing a race condition where the scene's language would get set by `ExplorerApplication` using a queryString then changed back to the document's defaults when the document loads. See [9bacad87](https://github.com/Holusion/dpo-voyager/commit/9bacad873446d401c6222079bb1bcae3b90b274c?diff=unified&w=0) and set the page's queryString to some other language to trigger the race condition. I had to create a new `UNSET` language value. This has minimal impact on the system because it always get set before it really gets used.

**A breaking change that I feel was necessary: **

Added a `document.setups[0].language.languages` property describing the document's allowed locales. Without it I couldn't get the `activeLanguages` feature to work reliably in every case. Additionally it allows an user to manually choose which languages will be available in the scene. As a nice bonus, the language picker is auto-synchronized to allow only those options everywhere (Tasks, CollectionPanel, LanguageMenu).

It won't break older scenes, gathering the allowed languages from existing data.

**Note :** it requires https://github.com/Smithsonian/ff-graph/pull/1 to work properly.


I left every commit separate to make those changes more readable: each message should be relatively self-describing. Most of them could be squashed together once this is ready to merge.

We tested it on a lot of our scenes already  (French-only, English-only, French-first, English-first) so this shouldn't cause too much unexpected trouble.
