### PR TITLE
Keep Copyright notices

### DIFF
--- a/source/client/components/CVDocument.ts
+++ b/source/client/components/CVDocument.ts
@@ -66,6 +66,7 @@ export default class CVDocument extends CRenderGraph
         download: types.Event("Document.Download"),
         title: types.String("Document.Title"),
         intro: types.String("Document.Intro", ""),
+        copyright: types.String("Document.Copyright", "(c) Smithsonian Institution. All rights reserved."),
     };
 
     protected static readonly outs = {
@@ -197,6 +198,8 @@ export default class CVDocument extends CRenderGraph
             this.ins.title.setValue(null);
         }
 
+        this.ins.copyright.setValue(documentData.asset.copyright ?? this.ins.copyright.schema.preset);
+
         // listen to load events on scene meta component
         this.onMetaComponent({ type: "CVMeta", object: this.root.meta, add: true, remove: false });
 
@@ -277,7 +280,7 @@ export default class CVDocument extends CRenderGraph
                 type: CVDocument.mimeType,
                 version: CVDocument.version,
                 generator: "Voyager",
-                copyright: "(c) Smithsonian Institution. All rights reserved."
+                copyright: this.ins.copyright.value,
             },
             scene: 0,
             scenes: [],

--- a/source/client/ui/story/CollectionPanel.ts
+++ b/source/client/ui/story/CollectionPanel.ts
@@ -52,6 +52,8 @@ export default class CollectionPanel extends DocumentView
                 <div class="sv-label">Intro</div>
                 <ff-text-edit name="intro" text=${this.activeDocument.ins.intro.value} @change=${this.onTextEdit}></ff-text-edit>
             </div>
+            <div class="sv-label">Copyright</div>
+            <ff-line-edit name="copyright" text=${this.activeDocument.ins.copyright.value} @change=${this.onTextEdit}></ff-line-edit>
         </div>`;
     }
 
@@ -76,6 +78,14 @@ export default class CollectionPanel extends DocumentView
                         allowedTags: [ 'i','b','p' ]
                     }    
                 ));
+            }
+            else if (target.name === "copyright") {
+                activeDoc.ins.copyright.setValue(sanitizeHtml(text,
+                    {
+                        allowedTags: [ 'i','b','a' ]
+                    }
+                ));
+            
             }
         }
     }


### PR DESCRIPTION
The document's `asset.copyright` field is currently always erased on save : the value is hardcoded in `CVDocument`.

I'd like it to be kept the same through saves as we have multiple sources that have different copyright requirements. A scene modification shouldn't change this field.

Additionally, I'd like to be able to edit the notice in the UI so I propose to add a text field in the collection panel. But maybe that's just me and this would be undesirable for everyone else? I'm OK handling this outside of voyager if necessary as long as it don't get replaced after each scene change.