### PR TITLE
add back ff-color-edit popup. Fix #257

### DIFF
--- a/source/client/ui/PropertyColor.ts
+++ b/source/client/ui/PropertyColor.ts
@@ -21,12 +21,10 @@ import Property from "@ff/graph/Property";
 import CustomElement, { customElement, property, PropertyValues, html } from "@ff/ui/CustomElement";
 
 import "@ff/ui/Button";
-import { IButtonClickEvent } from "@ff/ui/Button";
-
 import "@ff/ui/ColorEdit";
-import { IColorEditChangeEvent } from "@ff/ui/ColorEdit";
 
-import {getFocusableElements, focusTrap} from "../utils/focusHelpers";
+import type { IColorEditChangeEvent } from "@ff/ui/ColorEdit";
+import { focusTrap, getFocusableElements } from "client/utils/focusHelpers";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -39,7 +37,11 @@ export default class PropertyColor extends CustomElement
     @property({ type: String })
     name = "";
 
+    @property({attribute: false, type: Boolean})
+    pickerActive :boolean = false;
+
     protected color: Color = new Color();
+
 
     constructor()
     {
@@ -50,6 +52,11 @@ export default class PropertyColor extends CustomElement
     {
         super.firstConnected();
         this.classList.add("sv-property", "sv-property-color");
+    }
+
+    protected disconnected()
+    {
+        this.pickerActive = false;
     }
 
     protected update(changedProperties: PropertyValues): void
@@ -73,6 +80,15 @@ export default class PropertyColor extends CustomElement
             }
         }
 
+        if(changedProperties.has("pickerActive")){
+            if(this.pickerActive){
+                this.setPickerFocus();
+                document.addEventListener("pointerdown", this.onPointerDown, { capture: true, passive: true });
+            }else{
+                document.removeEventListener("pointerdown", this.onPointerDown, {capture: true});
+            }
+        }
+
         super.update(changedProperties);
     }
 
@@ -83,13 +99,25 @@ export default class PropertyColor extends CustomElement
         const color = this.color.toString();
 
         return html`<label class="ff-label ff-off">${name}</label>
-            <input type="color" value="${color}" @change=${this.onColorChange}>
+            <ff-button style="background-color: ${color}" title="${name} Color Picker" @click=${this.onButtonClick}></ff-button>
+            ${this.pickerActive ? html`<ff-color-edit .color=${this.color} @keydown=${e =>this.onKeyDown(e)} @change=${this.onColorChange}></ff-color-edit>` : null}
         `;
     }
 
-    protected onColorChange(event: Event)
+    protected async setPickerFocus()
     {
-        this.color = new Color((event.target as HTMLInputElement).value);
+        await this.updateComplete;
+        const container = this.getElementsByTagName("ff-color-edit").item(0) as HTMLElement;
+        (getFocusableElements(container)[0] as HTMLElement).focus();
+    }
+    
+    protected onButtonClick(event: Event)
+    {
+        this.pickerActive = !this.pickerActive;
+    }
+    
+    protected onColorChange(event: IColorEditChangeEvent)
+    {
         this.property.setValue(this.color.toRGBArray());
     }
 
@@ -97,5 +125,31 @@ export default class PropertyColor extends CustomElement
     {
         this.color.fromArray(value);
         this.requestUpdate();
+    }
+    // if color picker is active and user clicks outside, close picker
+    protected onPointerDown = (event: PointerEvent) => {
+        if (!this.pickerActive) {
+            return;
+        }
+
+        if (event.composedPath()[0] instanceof Node && this.contains(event.composedPath()[0] as Node)) {
+            return;
+        }
+        this.pickerActive = false;
+    }
+
+    protected onKeyDown(e: KeyboardEvent)
+    {
+        if (e.code === "Escape" || e.code === "Enter") {
+            e.preventDefault();
+            e.stopPropagation();
+            this.pickerActive = false;
+
+            (this.getElementsByTagName("ff-button")[0] as HTMLElement).focus();
+        }
+        else if(e.code === "Tab") {
+            const element = this.getElementsByTagName("ff-color-edit")[0] as HTMLElement;
+            focusTrap(getFocusableElements(element) as HTMLElement[], e);
+        }
     }
 }

--- a/source/client/ui/explorer/styles.scss
+++ b/source/client/ui/explorer/styles.scss
@@ -1248,22 +1248,31 @@ $tour-entry-indent: 12px;
   }
 
   &.sv-property-color {
-    input[type="color"] {
-      cursor: pointer;
-      border: none;
-      margin: 2px;
+    position: relative;
+    display: block;
+
+    & > .ff-button {
+      width: 26px;
+      max-width: 20ch;
       height: 26px;
       inline-size: 26px;
+      box-sizing: border-box;
       padding: 1px;
       background: $color-background;
       border-radius: 2px;
-      &::-webkit-color-swatch-wrapper {
-        padding: 0;
-      }
-      &::-webkit-color-swatch, &::-moz-color-swatch {
-        border: none;
-        border-radius: 2px;
-      }
+      border: none;
+      margin: 2px;
+    }
+
+    .ff-color-edit {
+      position: absolute;
+      width: 200px;
+      height: 180px;
+      right: 0px;
+      top: -188px;
+      background: $color-background-dark;
+      padding: 8px;
+      border-radius: 2px;
     }
   }
   


### PR DESCRIPTION
This PR reintroduces `<ff-color-edit>` instead of the native `<input type="color">` to solve accessibility issues.

I more or less copied-back the original implementation that existed before https://github.com/Smithsonian/dpo-voyager/pull/259 with a few changes:

- some styles updates (minor)
- use a `pickerActive` reactive property instead of forcing requestUpdate (more concise)
- Register `document.addEventListener("click",/* */)` to close picker when clicking somewhere else only when picker is active (small performance optimization)
- Add shortcut `Enter` to close picker

Sorry for the long delay in fixing this and more generally for the inconvenience caused by https://github.com/Smithsonian/dpo-voyager/pull/259, I clearly didn't test it enough before submitting.