### PR TITLE
accept other audio formats for AudioTaskView

### DIFF
--- a/source/client/ui/story/AudioTaskView.ts
+++ b/source/client/ui/story/AudioTaskView.ts
@@ -157,10 +157,19 @@ export default class AudioTaskView extends TaskView<CVAudioTask>
         }
 
         const id = element.parentElement.parentElement.id;
-        const fileProp = id == "filename" ? this.task.ins.filepath : this.task.ins.captionPath;
-        const extText = id == "filename" ? ".mp3" : ".vtt";
+        const type = (id == "filename")? "audio": "subs";
+        const fileProp = (type == "audio") ? this.task.ins.filepath : this.task.ins.captionPath;
 
-        if(filename.toLowerCase().endsWith(extText)) {
+        const ext = filename.toLowerCase().split(".").pop();
+        if(type === "subs" && ext != "vtt"){
+            Notification.show(`Unable to load - Only ${type === "subs"?".vtt":".mp3,.m4a"} files are currently supported.`, "warning");
+        }else if(type === "audio" && ["mp3","m4a","flac","ogg","wav"].indexOf(ext) === -1){
+            Notification.show(`Unable to load - Unsupported audio format .${ext}`, "warning");
+        }else{
+            if(type === "audio" && ext !== "mp3" && ext != "wav"){
+                // Only mp3 and wav have 100% browser support
+                Notification.show(`.${ext} audio file are not supported by some browsers`, "info", 3000);
+            }
             if(newFile !== null) {
                 const mediaManager = this.system.getMainComponent(CVMediaManager);
                 mediaManager.uploadFile(filename, newFile, mediaManager.root).then(() => fileProp.setValue(filename)).catch(e => {
@@ -171,9 +180,6 @@ export default class AudioTaskView extends TaskView<CVAudioTask>
             else {
                 fileProp.setValue(filename);
             }
-        }
-        else {
-            Notification.show(`Unable to load - Only ${extText} files are currently supported.`, "warning");
         }
 
         element.classList.remove("sv-drop-zone");


### PR DESCRIPTION
AudioTaskView currently only accepts `mp3` audio uploads. While this is the only compressed audio format that has 100% support (source: [caniuse.com](https://caniuse.com/?search=audio%20format) across browsers, some tools (eg: apple's audio recorder) now defaults to more modern formats.

I propose a softer requirement where partially-supported formats would just trigger an alert though I'll understand if you want to keep stricter requirements.