### PR TITLE
allow pasting color hex codes in sv-property-color. Fix #303

### DIFF
--- a/libs/ff-core/source/Color.ts
+++ b/libs/ff-core/source/Color.ts
@@ -299,26 +299,20 @@ export default class Color implements IVector4
     {
         color = color.trim().toLowerCase();
         color = Color.presets[color] || color;
-
-        let result = color.match(/^#?([0-9a-f]{3})$/i);
-        if (result) {
-            const text = result[1];
+        let text = /^#?([0-9a-f]{3,8})$/i.exec(color)?.[1];
+        if (text && (text.length === 3 || text.length == 4)) {
             const factor = 1 / 15;
             this.x = Number.parseInt(text.charAt(0), 16) * factor;
             this.y = Number.parseInt(text.charAt(1), 16) * factor;
             this.z = Number.parseInt(text.charAt(2), 16) * factor;
-            this.w = alpha;
+            this.w = (text.length == 4)? Number.parseInt(text.charAt(3), 16) * factor:alpha;
             return this;
-        }
-
-        result = color.match(/^#?([0-9a-f]{6})$/i);
-        if (result) {
-            const text = result[1];
+        }else if (text && (text.length === 6 || text.length == 8) ) {
             const factor = 1 / 255;
             this.x = Number.parseInt(text.substr(0,2), 16) * factor;
             this.y = Number.parseInt(text.substr(2,2), 16) * factor;
             this.z = Number.parseInt(text.substr(4,2), 16) * factor;
-            this.w = alpha;
+            this.w =  (text.length == 8)? Number.parseInt(text.substr(6,2), 16) * factor:alpha;
             return this;
         }
 
@@ -480,13 +474,11 @@ export default class Color implements IVector4
 
     toString(includeAlpha?: boolean): string
     {
+        let bytes = [this.redByte, this.greenByte, this.blueByte];
         if (includeAlpha || (typeof includeAlpha === "undefined" && this.w < 1)) {
-            return `rgba(${this.redByte}, ${this.greenByte}, ${this.blueByte}, ${this.w})`;
+            bytes.push(this.alphaByte);
         }
-        else {
-            const value = (1 << 24) + (this.redByte << 16) + (this.greenByte << 8) + this.blueByte;
-            return `#${value.toString(16).slice(1)}`;
-        }
+        return "#"+bytes.map(b=>b.toString(16).padStart(2,"0")).join("");
     }
 
     private static presets = {

--- a/libs/ff-core/source/Color.ts
+++ b/libs/ff-core/source/Color.ts
@@ -478,9 +478,9 @@ export default class Color implements IVector4
         return [ this.r, this.g, this.b, this.a ];
     }
 
-    toString(includeAlpha: boolean = true): string
+    toString(includeAlpha?: boolean): string
     {
-        if (includeAlpha && this.w < 1) {
+        if (includeAlpha || (typeof includeAlpha === "undefined" && this.w < 1)) {
             return `rgba(${this.redByte}, ${this.greenByte}, ${this.blueByte}, ${this.w})`;
         }
         else {

--- a/libs/ff-core/test/Color.test.ts
+++ b/libs/ff-core/test/Color.test.ts
@@ -27,12 +27,28 @@ export default function() {
             assert.approximately(c.w, 0xff / 255, eps, "alpha");
         });
 
+        test("fromString - static constructor from 8-digit hex string #4d7e0988", function() {
+            const c = Color.fromString("#4d7e0908");
+            assert.approximately(c.x, 0x4d / 255, eps, "red");
+            assert.approximately(c.y, 0x7e / 255, eps, "green");
+            assert.approximately(c.z, 0x09 / 255, eps, "blue");
+            assert.approximately(c.w, 0x08 / 255, eps, "alpha");
+        });
+    
         test("fromString - static constructor from 3-digit hex string #6ea", function() {
             const c = Color.fromString("#6ea");
             assert.approximately(c.x, 0x66 / 255, eps, "red");
             assert.approximately(c.y, 0xee / 255, eps, "green");
             assert.approximately(c.z, 0xaa / 255, eps, "blue");
             assert.approximately(c.w, 0xff / 255, eps, "alpha");
+        });
+    
+        test("fromString - static constructor from 4-digit hex string #6ea", function() {
+            const c = Color.fromString("#6ea3");
+            assert.approximately(c.x, 0x66 / 255, eps, "red");
+            assert.approximately(c.y, 0xee / 255, eps, "green");
+            assert.approximately(c.z, 0xaa / 255, eps, "blue");
+            assert.approximately(c.w, 0x33 / 255, eps, "alpha");
         });
 
         test("fromString - static constructor from rgb(47, 25, 243)", function() {

--- a/source/client/schema/model.ts
+++ b/source/client/schema/model.ts
@@ -16,7 +16,7 @@
  */
 
 import { Dictionary } from "@ff/core/types";
-import { ColorRGBA, EUnitType, TUnitType, Vector3, Vector4 } from "./common";
+import { ColorRGB, EUnitType, TUnitType, Vector3, Vector4 } from "./common";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -132,7 +132,7 @@ export interface IAsset
 
 export interface IPBRMaterialSettings
 {
-    color?: ColorRGBA
+    color?: ColorRGB
     opacity?: number;
     hiddenOpacity?: number;
     roughness?: number;

--- a/source/client/ui/PropertyColor.ts
+++ b/source/client/ui/PropertyColor.ts
@@ -40,6 +40,9 @@ export default class PropertyColor extends CustomElement
     @property({attribute: false, type: Boolean})
     pickerActive :boolean = false;
 
+    @property({type: Boolean})
+    compact :boolean = false;
+
     protected color: Color = new Color();
 
 
@@ -99,7 +102,18 @@ export default class PropertyColor extends CustomElement
         const color = this.color.toString();
 
         return html`<label class="ff-label ff-off">${name}</label>
-            <ff-button style="background-color: ${color}" title="${name} Color Picker" @click=${this.onButtonClick}></ff-button>
+            <span class="sv-property-field">
+                ${this.compact?null:html`<input class="ff-input"
+                        type="text"
+                        pattern="(0x|#)?[0-9a-fA-F]"
+                        .value=${color}
+                        @change=${(ev)=>{
+                            this.color.setString(ev.target.value);
+                            this.onColorChange();
+                        }}
+                    >`}
+                <ff-button style="background-color: ${color}" title="${name} Color Picker" @click=${this.onButtonClick}></ff-button>
+            </span>
             ${this.pickerActive ? html`<ff-color-edit .color=${this.color} @keydown=${e =>this.onKeyDown(e)} @change=${this.onColorChange}></ff-color-edit>` : null}
         `;
     }
@@ -116,7 +130,7 @@ export default class PropertyColor extends CustomElement
         this.pickerActive = !this.pickerActive;
     }
     
-    protected onColorChange(event: IColorEditChangeEvent)
+    protected onColorChange()
     {
         this.property.setValue(this.color.toRGBArray());
     }

--- a/source/client/ui/PropertyColor.ts
+++ b/source/client/ui/PropertyColor.ts
@@ -114,7 +114,9 @@ export default class PropertyColor extends CustomElement
                             try{
                                 this.color.setString(ev.target.value);
                                 this.onColorChange();
+                                ev.target.setCustomValidity("");
                             }catch(e){
+                                ev.target.setCustomValidity(e.message);
                                 Notification.show(`Not a valid color: ${ev.target.value}`, "warning", 1000);
                             }
                         }}

--- a/source/client/ui/explorer/styles.scss
+++ b/source/client/ui/explorer/styles.scss
@@ -1248,17 +1248,14 @@ $tour-entry-indent: 12px;
     position: relative;
     display: block;
 
-    & > .ff-button {
-      width: 26px;
-      max-width: 20ch;
-      height: 26px;
-      inline-size: 26px;
-      box-sizing: border-box;
-      padding: 1px;
-      background: $color-background;
-      border-radius: 2px;
-      border: none;
-      margin: 2px;
+    & > .sv-property-field {
+      display: flex;
+      
+      .ff-button{
+        min-width: 1em;
+        border-radius: 2px;
+        margin: 2px;
+      }
     }
 
     .ff-color-edit {


### PR DESCRIPTION
First commit implements the text input. It looks like this : 

![image](https://github.com/user-attachments/assets/3cc17554-2f75-4923-920a-3676d4187728)

Then I wanted to test the various input formats. For reference, `@ff/core/Color` is able to parse  3-6 chars hex, `rgb()`, `hsl()` notations. All of which are parsed OK, though they get auto-converted to 6-chars hex immediately. Dealing with this would probably require storing some internal string-state inside the `Color` class but would still be lost on save. Let me know if you think it's needed.

Then I wanted to test rgba notations. I noticed no property currently use rgba. There is `Material.BaseColor` from **CVModel2** that is mapped to a Vector4, but the error is the other way around: It gets assigned to a `THREE.Color` that have no alpha. I fixed that in 7073d361c9b16598f4aed8ccf4f2db29aaf425a7.

I still temporarily switched a property to RGBA to test things. It was broken in various minor ways, I fixed that in b8c886c6b975d5c729f1de9f4b2d7b472661aa8b, we might need it in the future.

Then I noticed the serialized alpha colors would be using the `rgba()`notation which overflows from our inputs. Since `#rrggbbaa` is now [widely supported](https://caniuse.com/css-rrggbbaa), I propose to change the default and add the ability to parse it in d9d5ba748a94309f11da1c3244d41e880c02d958. I modified the serialization technique because the bit shift doesn't like 32bits offsets. I also added unit tests even though they don't run as they are now, expect a PR about this soon.

02d11c6d49f43266d5d08d440f62fd3db252b529 adds a simple validity check for colors that fail to parse. It's invisible now but it will show if/when we add some style for invalid inputs.
