### PR TITLE
update-in-place for three r168

### DIFF
--- a/libs/ff-scene/source/components/CCamera.ts
+++ b/libs/ff-scene/source/components/CCamera.ts
@@ -5,7 +5,7 @@
  * License: MIT
  */
 
-import { Vector3, Euler, Quaternion, EulerOrder } from "three";
+import { Vector3, Euler, Quaternion, EulerOrder, Matrix4 } from "three";
 
 import { Node, types } from "@ff/graph/Component";
 
@@ -107,7 +107,7 @@ export default class CCamera extends CObject3D
      * Updating the properties then also updates the matrix of the internal universal camera object.
      * @param matrix A 4x4 transform matrix. If omitted, properties are updated from the matrix of the internal camera.
      */
-    setPropertiesFromMatrix(matrix?: THREE.Matrix4)
+    setPropertiesFromMatrix(matrix?: Matrix4)
     {
         const silent = !matrix;
         matrix = matrix || this.object3D.matrix;

--- a/libs/ff-scene/source/components/CObject3D.ts
+++ b/libs/ff-scene/source/components/CObject3D.ts
@@ -35,7 +35,7 @@ export interface IObject3DObjectEvent extends ITypedEvent<"object">
 }
 
 /**
- * Base class for drawable components. Wraps a THREE.Object3D based instance.
+ * Base class for drawable components. Wraps a Object3D based instance.
  * If component is added to a node together with a [[Transform]] component,
  * it is automatically added as a child to the transform.
  */
@@ -63,7 +63,7 @@ export default class CObject3D extends Component implements ICObject3D
     outs = this.addOutputs(CObject3D.object3DOuts);
 
 
-    private _object3D: THREE.Object3D = null;
+    private _object3D: Object3D = null;
     private _isPickable = false;
 
     constructor(node: Node, id: string)
@@ -91,17 +91,17 @@ export default class CObject3D extends Component implements ICObject3D
         const transform = this.transform;
         return transform ? transform.getParentComponent(CScene, true) : undefined;
     }
-    /** The underlying [[THREE.Object3D]] of this component. */
-    get object3D(): THREE.Object3D | null {
+    /** The underlying [[Object3D]] of this component. */
+    get object3D(): Object3D | null {
         return this._object3D;
     }
 
     /**
-     * Assigns a [[THREE.Object3D]] to this component. The object automatically becomes a child
+     * Assigns a [[Object3D]] to this component. The object automatically becomes a child
      * of the parent component's object.
      * @param object
      */
-    set object3D(object: THREE.Object3D)
+    set object3D(object: Object3D)
     {
         const currentObject = this._object3D;
         if (currentObject) {
@@ -254,33 +254,33 @@ export default class CObject3D extends Component implements ICObject3D
         return true;
     }
 
-    protected onAddToParent(parent: THREE.Object3D)
+    protected onAddToParent(parent: Object3D)
     {
         parent.add(this._object3D);
     }
 
-    protected onRemoveFromParent(parent: THREE.Object3D)
+    protected onRemoveFromParent(parent: Object3D)
     {
         parent.remove(this._object3D);
     }
 
     /**
-     * Adds a [[THREE.Object3D]] as a child to this component's object.
+     * Adds a [[Object3D]] as a child to this component's object.
      * Registers the object with the picking service to make it pickable.
      * @param object
      */
-    protected addObject3D(object: THREE.Object3D)
+    protected addObject3D(object: Object3D)
     {
         this._object3D.add(object);
         this.registerPickableObject3D(object, true);
     }
 
     /**
-     * Removes a [[THREE.Object3D]] child from this component's object.
+     * Removes a [[Object3D]] child from this component's object.
      * Also unregisters the object from the picking service.
      * @param object
      */
-    protected removeObject3D(object: THREE.Object3D)
+    protected removeObject3D(object: Object3D)
     {
         this.unregisterPickableObject3D(object, true);
         this._object3D.remove(object);
@@ -292,7 +292,7 @@ export default class CObject3D extends Component implements ICObject3D
      * @param object
      * @param recursive
      */
-    protected registerPickableObject3D(object: THREE.Object3D, recursive: boolean)
+    protected registerPickableObject3D(object: Object3D, recursive: boolean)
     {
         GPUPicker.add(object, recursive);
     }
@@ -303,14 +303,14 @@ export default class CObject3D extends Component implements ICObject3D
      * @param object
      * @param recursive
      */
-    protected unregisterPickableObject3D(object: THREE.Object3D, recursive: boolean)
+    protected unregisterPickableObject3D(object: Object3D, recursive: boolean)
     {
         GPUPicker.remove(object, recursive);
     }
 
     private _onParent(event: IComponentEvent<ICObject3D>)
     {
-        // add this THREE.Object3D to the parent THREE.Object3D
+        // add this Object3D to the parent Object3D
         if (this._object3D && !this._object3D.parent && event.add) {
             this.onAddToParent(event.object.object3D);
         }

--- a/libs/ff-three/source/Floor.ts
+++ b/libs/ff-three/source/Floor.ts
@@ -52,8 +52,8 @@ export interface IFloorMaterialParameters extends MeshPhongMaterialParameters
 
 export class FloorMaterial extends MeshPhongMaterial
 {
-    isMeshPhongMaterial: boolean;
-    isFloorMaterial: boolean;
+    readonly isMeshPhongMaterial = true;
+    readonly isFloorMaterial = true;
 
     uniforms: {
     };
@@ -68,9 +68,6 @@ export class FloorMaterial extends MeshPhongMaterial
         super(params);
 
         this.type = "FloorMaterial";
-
-        this.isMeshPhongMaterial = true;
-        this.isFloorMaterial = true;
 
         this.defines = {};
         this.uniforms = UniformsUtils.merge([

--- a/libs/ff-three/source/Grid.ts
+++ b/libs/ff-three/source/Grid.ts
@@ -20,8 +20,8 @@ export interface IGridProps
     size: number;
     mainDivisions: number;
     subDivisions: number;
-    mainColor: THREE.Color | string | number;
-    subColor: THREE.Color | string | number;
+    mainColor: Color | string | number;
+    subColor: Color | string | number;
 }
 
 export default class Grid extends LineSegments
@@ -51,7 +51,7 @@ export default class Grid extends LineSegments
         this.geometry = Grid.generate(props);
     }
 
-    protected static generate(props: IGridProps): THREE.BufferGeometry
+    protected static generate(props: IGridProps): BufferGeometry
     {
         const mainColor = new Color(props.mainColor as any);
         const subColor = new Color(props.subColor as any);

--- a/libs/ff-three/source/HTMLSprite.ts
+++ b/libs/ff-three/source/HTMLSprite.ts
@@ -10,6 +10,7 @@ import {
     Camera,
     Vector2,
     Vector3,
+    Object3DEventMap,
 } from "three";
 
 import CustomElement, { customElement, html } from "@ff/ui/CustomElement";
@@ -31,7 +32,7 @@ export enum EQuadrant { TopRight, TopLeft, BottomLeft, BottomRight }
  * A Three.js Object representing a 3D renderable part and a 2D (HTML) part.
  * HTML sprites should have a [[HTMLSpriteGroup]] as their parent.
  */
-export default class HTMLSprite extends Object3D
+export default class HTMLSprite<EventMap extends Object3DEventMap = Object3DEventMap> extends Object3D<EventMap>
 {
     readonly isHTMLSprite = true;
 

--- a/libs/ff-three/source/UniversalCamera.ts
+++ b/libs/ff-three/source/UniversalCamera.ts
@@ -159,7 +159,7 @@ export default class UniversalCamera extends Camera
         // TODO: Implement
     }
 
-    moveToView(boundingBox: THREE.Box3)
+    moveToView(boundingBox: Box3)
     {
         this.updateMatrixWorld(false);
         _box.copy(boundingBox);
@@ -278,20 +278,20 @@ export default class UniversalCamera extends Camera
     toJSON(meta)
     {
         const data = super.toJSON(meta);
-
-        data.object.fov = this.fov;
-        data.object.size = this.size;
-        data.object.aspect = this.aspect;
-        data.object.zoom = this.zoom;
-        data.object.near = this.near;
-        data.object.far = this.far;
-
-        data.object.focus = this.focus;
-        data.object.filmGauge = this.filmGauge;
-        data.object.filmOffset = this.filmOffset;
+        Object.assign(data.object, {
+            fov: this.fov,
+            size: this.size,
+            aspect: this.aspect,
+            zoom: this.zoom,
+            near: this.near,
+            far: this.far,
+            focus: this.focus,
+            filmGauge: this.filmGauge,
+            filmOffset: this.filmOffset,
+        });
 
         if (this.view !== null) {
-            data.object.view = Object.assign({}, this.view);
+            (data.object as any).view = Object.assign({}, this.view);
         }
 
         return data;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "voyager",
-    "version": "0.42.0",
+    "version": "0.44.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "voyager",
-            "version": "0.42.0",
+            "version": "0.44.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "ajv": "^8.6.2",
@@ -30,7 +30,7 @@
                 "simple-dropzone": "^0.8.3",
                 "stream-browserify": "^3.0.0",
                 "style-loader": "^3.3.1",
-                "three": "^0.158.0",
+                "three": "^0.168.0",
                 "tinymce": "^6.3.1",
                 "toposort": "^2.0.2",
                 "webdav": "^5.3.0",
@@ -41,7 +41,7 @@
                 "@types/chai": "^4.2.21",
                 "@types/mocha": "^9.0.0",
                 "@types/node": "^14.0.26",
-                "@types/three": "^0.155.1",
+                "@types/three": "^0.168.0",
                 "chai": "^4.3.8",
                 "concurrently": "^6.2.1",
                 "copy-webpack-plugin": "^11.0.0",
@@ -184,9 +184,9 @@
             }
         },
         "node_modules/@tweenjs/tween.js": {
-            "version": "18.6.4",
-            "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.6.4.tgz",
-            "integrity": "sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==",
+            "version": "23.1.3",
+            "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+            "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
             "dev": true
         },
         "node_modules/@types/chai": {
@@ -247,16 +247,16 @@
             "dev": true
         },
         "node_modules/@types/three": {
-            "version": "0.155.1",
-            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.155.1.tgz",
-            "integrity": "sha512-uNUwnz/wWRxahjIqTtDYQ1qdE1R1py21obxfuILkT+kKrjocMwRLQQA1l8nMxfQU7VXb7CXu04ucMo8OqZt4ZA==",
+            "version": "0.168.0",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.168.0.tgz",
+            "integrity": "sha512-qAGLGzbaYgkkonOBfwOr+TZpOskPfFjrDAj801WQSVkUz0/D9zwir4vhruJ/CC/GteywzR9pqeVVfs5th/2oKw==",
             "dev": true,
             "dependencies": {
-                "@tweenjs/tween.js": "~18.6.4",
+                "@tweenjs/tween.js": "~23.1.3",
                 "@types/stats.js": "*",
                 "@types/webxr": "*",
-                "fflate": "~0.6.9",
-                "lil-gui": "~0.17.0",
+                "@webgpu/types": "*",
+                "fflate": "~0.8.2",
                 "meshoptimizer": "~0.18.1"
             }
         },
@@ -396,6 +396,12 @@
                 "@webassemblyjs/ast": "1.11.6",
                 "@xtuc/long": "4.2.2"
             }
+        },
+        "node_modules/@webgpu/types": {
+            "version": "0.1.44",
+            "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.44.tgz",
+            "integrity": "sha512-JDpYJN5E/asw84LTYhKyvPpxGnD+bAKPtpW9Ilurf7cZpxaTbxkQcGwOd7jgB9BPBrTYQ+32ufo4HiuomTjHNQ==",
+            "dev": true
         },
         "node_modules/@webpack-cli/configtest": {
             "version": "1.1.1",
@@ -2127,9 +2133,9 @@
             }
         },
         "node_modules/fflate": {
-            "version": "0.6.10",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
-            "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
             "dev": true
         },
         "node_modules/filename-reserved-regex": {
@@ -3064,12 +3070,6 @@
             "bin": {
                 "nopt": "bin/nopt.js"
             }
-        },
-        "node_modules/lil-gui": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.17.0.tgz",
-            "integrity": "sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==",
-            "dev": true
         },
         "node_modules/lilconfig": {
             "version": "2.0.4",
@@ -5791,9 +5791,9 @@
             "dev": true
         },
         "node_modules/three": {
-            "version": "0.158.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.158.0.tgz",
-            "integrity": "sha512-TALj4EOpdDPF1henk2Q+s17K61uEAAWQ7TJB68nr7FKxqwyDr3msOt5IWdbGm4TaWKjrtWS8DJJWe9JnvsWOhQ=="
+            "version": "0.168.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+            "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw=="
         },
         "node_modules/timsort": {
             "version": "0.3.0",
@@ -6793,9 +6793,9 @@
             "dev": true
         },
         "@tweenjs/tween.js": {
-            "version": "18.6.4",
-            "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-18.6.4.tgz",
-            "integrity": "sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==",
+            "version": "23.1.3",
+            "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+            "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
             "dev": true
         },
         "@types/chai": {
@@ -6856,16 +6856,16 @@
             "dev": true
         },
         "@types/three": {
-            "version": "0.155.1",
-            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.155.1.tgz",
-            "integrity": "sha512-uNUwnz/wWRxahjIqTtDYQ1qdE1R1py21obxfuILkT+kKrjocMwRLQQA1l8nMxfQU7VXb7CXu04ucMo8OqZt4ZA==",
+            "version": "0.168.0",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.168.0.tgz",
+            "integrity": "sha512-qAGLGzbaYgkkonOBfwOr+TZpOskPfFjrDAj801WQSVkUz0/D9zwir4vhruJ/CC/GteywzR9pqeVVfs5th/2oKw==",
             "dev": true,
             "requires": {
-                "@tweenjs/tween.js": "~18.6.4",
+                "@tweenjs/tween.js": "~23.1.3",
                 "@types/stats.js": "*",
                 "@types/webxr": "*",
-                "fflate": "~0.6.9",
-                "lil-gui": "~0.17.0",
+                "@webgpu/types": "*",
+                "fflate": "~0.8.2",
                 "meshoptimizer": "~0.18.1"
             }
         },
@@ -7005,6 +7005,12 @@
                 "@webassemblyjs/ast": "1.11.6",
                 "@xtuc/long": "4.2.2"
             }
+        },
+        "@webgpu/types": {
+            "version": "0.1.44",
+            "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.44.tgz",
+            "integrity": "sha512-JDpYJN5E/asw84LTYhKyvPpxGnD+bAKPtpW9Ilurf7cZpxaTbxkQcGwOd7jgB9BPBrTYQ+32ufo4HiuomTjHNQ==",
+            "dev": true
         },
         "@webpack-cli/configtest": {
             "version": "1.1.1",
@@ -8236,9 +8242,9 @@
             }
         },
         "fflate": {
-            "version": "0.6.10",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
-            "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
             "dev": true
         },
         "filename-reserved-regex": {
@@ -8914,12 +8920,6 @@
                     }
                 }
             }
-        },
-        "lil-gui": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.17.0.tgz",
-            "integrity": "sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==",
-            "dev": true
         },
         "lilconfig": {
             "version": "2.0.4",
@@ -10855,9 +10855,9 @@
             }
         },
         "three": {
-            "version": "0.158.0",
-            "resolved": "https://registry.npmjs.org/three/-/three-0.158.0.tgz",
-            "integrity": "sha512-TALj4EOpdDPF1henk2Q+s17K61uEAAWQ7TJB68nr7FKxqwyDr3msOt5IWdbGm4TaWKjrtWS8DJJWe9JnvsWOhQ=="
+            "version": "0.168.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
+            "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw=="
         },
         "timsort": {
             "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
             "node_modules/@ff/server"
         ]
     },
-    "engines":{
+    "engines": {
         "node": ">=14.15.0"
     },
     "repository": {
@@ -72,7 +72,7 @@
         "simple-dropzone": "^0.8.3",
         "stream-browserify": "^3.0.0",
         "style-loader": "^3.3.1",
-        "three": "^0.158.0",
+        "three": "^0.168.0",
         "tinymce": "^6.3.1",
         "toposort": "^2.0.2",
         "webdav": "^5.3.0",
@@ -83,7 +83,7 @@
         "@types/chai": "^4.2.21",
         "@types/mocha": "^9.0.0",
         "@types/node": "^14.0.26",
-        "@types/three": "^0.155.1",
+        "@types/three": "^0.168.0",
         "chai": "^4.3.8",
         "concurrently": "^6.2.1",
         "copy-webpack-plugin": "^11.0.0",

--- a/source/client/annotations/AnnotationSprite.ts
+++ b/source/client/annotations/AnnotationSprite.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Object3D, Camera, ArrayCamera, PerspectiveCamera, Vector3 } from "three";
+import { Object3D, Camera, ArrayCamera, PerspectiveCamera, Vector3, Object3DEventMap } from "three";
 
 import { ITypedEvent } from "@ff/core/Publisher";
 import HTMLSprite, { SpriteElement, html } from "@ff/three/HTMLSprite";
@@ -54,6 +54,11 @@ export interface IAnnotationLinkEvent extends ITypedEvent<"link">
     link: string;
 }
 
+export interface IAnnotationEventMap extends Object3DEventMap{
+    click: IAnnotationClickEvent;
+    link: IAnnotationLinkEvent;
+}
+
 /**
  * Defines the visual appearance of an annotation.
  * An annotation consists of a 3D (WebGL) part and a 2D (HTML) part.
@@ -62,7 +67,7 @@ export interface IAnnotationLinkEvent extends ITypedEvent<"link">
  * - *"click"* Emitted if the user clicks on the annotation.
  * - *"link"* Emitted if the user activates a link on the annotation.
  */
-export default class AnnotationSprite extends HTMLSprite
+export default class AnnotationSprite extends HTMLSprite<IAnnotationEventMap>
 {
     static readonly typeName: string = "Annotation";
 

--- a/source/client/components/CVAnnotationView.ts
+++ b/source/client/components/CVAnnotationView.ts
@@ -20,7 +20,7 @@ import { Dictionary } from "@ff/core/types";
 import { ITypedEvent, Node, types } from "@ff/graph/Component";
 
 import Viewport, { IViewportDisposeEvent } from "@ff/three/Viewport";
-import HTMLSpriteGroup, { HTMLSprite } from "@ff/three/HTMLSpriteGroup";
+import HTMLSpriteGroup from "@ff/three/HTMLSpriteGroup";
 
 import CObject3D, { IPointerEvent, IRenderContext } from "@ff/scene/components/CObject3D";
 import CRenderer from "@ff/scene/components/CRenderer";
@@ -95,7 +95,7 @@ export default class CVAnnotationView extends CObject3D
     private _annotations: Dictionary<Annotation> = {};
 
     private _viewports = new Set<Viewport>();
-    private _sprites: Dictionary<HTMLSprite> = {};
+    private _sprites: Dictionary<AnnotationSprite> = {};
 
     private _truncateLock = false;
     private _activeView = false;

--- a/source/client/components/CVAssetReader.ts
+++ b/source/client/components/CVAssetReader.ts
@@ -25,6 +25,7 @@ import FontReader, { IBitmapFont } from "../io/FontReader";
 
 import CVAssetManager from "./CVAssetManager";
 import CRenderer from "@ff/scene/components/CRenderer";
+import { Object3D, BufferGeometry, Texture } from "three";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -103,19 +104,19 @@ export default class CVAssetReader extends Component
         return this.fileLoader.getText(url);
     }
 
-    async getModel(assetPath: string): Promise<THREE.Object3D>
+    async getModel(assetPath: string): Promise<Object3D>
     {
         const url = this.assetManager.getAssetUrl(assetPath);
         return this.modelLoader.get(url);
     }
 
-    async getGeometry(assetPath: string): Promise<THREE.BufferGeometry>
+    async getGeometry(assetPath: string): Promise<BufferGeometry>
     {
         const url = this.assetManager.getAssetUrl(assetPath);
         return this.geometryLoader.get(url);
     }
 
-    async getTexture(assetPath: string): Promise<THREE.Texture>
+    async getTexture(assetPath: string): Promise<Texture>
     {
         const url = this.assetManager.getAssetUrl(assetPath);
         return this.textureLoader.get(url);
@@ -127,7 +128,7 @@ export default class CVAssetReader extends Component
         return this.fontReader.load(url);
     }
 
-    async getSystemTexture(assetPath: string): Promise<THREE.Texture>
+    async getSystemTexture(assetPath: string): Promise<Texture>
     {
         const url = this.getSystemAssetUrl(assetPath);
         return this.textureLoader.get(url);

--- a/source/client/schema/document.ts
+++ b/source/client/schema/document.ts
@@ -21,6 +21,7 @@ import { EUnitType, TUnitType, Vector3, Quaternion, Matrix4, ColorRGB } from "./
 import { IMeta } from "./meta";
 import { IModel } from "./model";
 import { ISetup } from "./setup";
+import { QuaternionTuple } from "three";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -75,7 +76,7 @@ export interface INode
 
     matrix?: Matrix4;
     translation?: Vector3;
-    rotation?: Quaternion;
+    rotation?: QuaternionTuple;
     scale?: Vector3;
 
     camera?: Index;

--- a/source/client/schema/model.ts
+++ b/source/client/schema/model.ts
@@ -17,6 +17,7 @@
 
 import { Dictionary } from "@ff/core/types";
 import { ColorRGBA, EUnitType, TUnitType, Vector3, Vector4 } from "./common";
+import { QuaternionTuple } from "three";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -51,7 +52,7 @@ export interface IModel
     overlayMap?: number;
     shadowSide?: TSideType;
     translation?: Vector3;
-    rotation?: Vector4;
+    rotation?: QuaternionTuple;
     boundingBox?: IBoundingBox;
     material?: IPBRMaterialSettings;
     annotations?: IAnnotation[];

--- a/source/client/shaders/UberPBRAdvMaterial.ts
+++ b/source/client/shaders/UberPBRAdvMaterial.ts
@@ -34,9 +34,9 @@ export interface IUberPBRAdvShaderProps extends MeshPhysicalMaterialParameters
 
 export default class UberPBRMaterial extends MeshPhysicalMaterial
 {
-    isUberPBRMaterial: boolean;
-    isMeshStandardMaterial: boolean;
-    isMeshPhysicalMaterial: boolean;
+    readonly isUberPBRMaterial = true;
+    readonly isMeshStandardMaterial = true;
+    readonly isMeshPhysicalMaterial = true;
 
     uniforms: {
         aoMapMix: { value: Vector3 },
@@ -66,9 +66,6 @@ export default class UberPBRMaterial extends MeshPhysicalMaterial
 
         this.type = "UberPBRAdvMaterial";
 
-        this.isUberPBRMaterial = true;
-        this.isMeshStandardMaterial = true;
-        this.isMeshPhysicalMaterial = true;
 
         this.defines = {
             "STANDARD": true,
@@ -88,7 +85,7 @@ export default class UberPBRMaterial extends MeshPhysicalMaterial
                 cutPlaneColor: { value: new Vector3(1, 0, 0) },
                 zoneMap: { value: null },
             }
-        ]);
+        ]) as any;
 
         this._aoMapMix = this.uniforms.aoMapMix.value;
         this._cutPlaneDirection = this.uniforms.cutPlaneDirection.value;

--- a/source/client/shaders/UberPBRMaterial.ts
+++ b/source/client/shaders/UberPBRMaterial.ts
@@ -34,9 +34,9 @@ export interface IUberPBRShaderProps extends MeshStandardMaterialParameters
 
 export default class UberPBRMaterial extends MeshStandardMaterial
 {
-    isUberPBRMaterial: boolean;
-    isMeshStandardMaterial: boolean;
-    isMeshPhysicalMaterial: boolean;
+    readonly isUberPBRMaterial = true;
+    readonly isMeshStandardMaterial = true;
+    readonly isMeshPhysicalMaterial = false;
 
     uniforms: {
         aoMapMix: { value: Vector3 },
@@ -66,10 +66,6 @@ export default class UberPBRMaterial extends MeshStandardMaterial
 
         this.type = "UberPBRMaterial";
 
-        this.isUberPBRMaterial = true;
-        this.isMeshStandardMaterial = true;
-        this.isMeshPhysicalMaterial = false;
-
         this.defines = {
             "STANDARD": true,
             "PHYSICAL": false,
@@ -88,7 +84,7 @@ export default class UberPBRMaterial extends MeshStandardMaterial
                 cutPlaneColor: { value: new Vector3(1, 0, 0) },
                 zoneMap: { value: null },
             }
-        ]);
+        ]) as any;
 
         this._aoMapMix = this.uniforms.aoMapMix.value;
         this._cutPlaneDirection = this.uniforms.cutPlaneDirection.value;

--- a/source/client/shaders/uberPBRShader.frag
+++ b/source/client/shaders/uberPBRShader.frag
@@ -33,6 +33,10 @@ uniform float opacity;
 	uniform float clearcoatRoughness;
 #endif
 
+#ifdef USE_DISPERSION
+	uniform float dispersion;
+#endif
+
 #ifdef USE_IRIDESCENCE
 	uniform float iridescence;
 	uniform float iridescenceIOR;
@@ -128,10 +132,11 @@ void main() {
             discard;
         }
     #endif
+		
+	vec4 diffuseColor = vec4( diffuse, opacity );
 
 	#include <clipping_planes_fragment>
 
-	vec4 diffuseColor = vec4( diffuse, opacity );
 	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );
 	vec3 totalEmissiveRadiance = emissive;
 

--- a/source/client/shaders/uberPBRShader.vert
+++ b/source/client/shaders/uberPBRShader.vert
@@ -15,6 +15,7 @@ varying vec3 vViewPosition;
 #endif
 
 #include <common>
+#include <batching_pars_vertex>
 #include <uv_pars_vertex>
 #include <displacementmap_pars_vertex>
 #include <color_pars_vertex>
@@ -48,7 +49,9 @@ void main() {
 #endif
 
 	#include <color_vertex>
+	#include <morphinstance_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>


### PR DESCRIPTION
I needed an update to three.js to test https://github.com/mrdoob/three.js/pull/27098 from r161 so I thought I might as well make a PR for it.

There was some uninteresting types rewrites, some frag/vert updates that I extracted from a diff of the physical shader from r158 to r168. I only used this in local tests so it might break in unexpected ways.