### PR TITLE
Improved Story viewport brackets and helpers

### DIFF
--- a/libs/ff-scene/source/components/CDirectionalLight.ts
+++ b/libs/ff-scene/source/components/CDirectionalLight.ts
@@ -20,7 +20,10 @@ export default class CDirectionalLight extends CLight
     protected static readonly dirLightIns = {
         position: types.Vector3("Light.Position"),
         target: types.Vector3("Light.Target", [ 0, -1, 0 ]),
-        shadowSize: types.Number("Shadow.Size", 100),
+        shadowSize: types.Number("Shadow.Size", {
+            preset: 100,
+            min: 0,
+        }),
     };
 
     ins = this.addInputs<CLight, typeof CDirectionalLight["dirLightIns"]>(CDirectionalLight.dirLightIns);

--- a/libs/ff-scene/source/components/CHemisphereLight.ts
+++ b/libs/ff-scene/source/components/CHemisphereLight.ts
@@ -7,7 +7,10 @@ import CLight from "./CLight";
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
+/**
+ * Implementeation of [HemisphereLight](https://threejs.org/docs/?q=HemisphereLight#api/en/lights/HemisphereLight) from three.js
+ * It does NOT work on Standard materials that have a metallic value of 1
+ */
 export default class CHemisphereLight extends CLight
 {
     static readonly typeName: string = "CHemisphereLight";

--- a/libs/ff-scene/source/components/CLight.ts
+++ b/libs/ff-scene/source/components/CLight.ts
@@ -26,7 +26,10 @@ export default class CLight extends CObject3D
 
     protected static readonly lightIns = {
         color: types.ColorRGB("Light.Color"),
-        intensity: types.Number("Light.Intensity", 1),
+        intensity: types.Number("Light.Intensity", {
+            preset:1,
+            min: 0,
+        }),
         shadowEnabled: types.Boolean("Shadow.Enabled"),
         shadowResolution: types.Enum("Shadow.Resolution", EShadowMapResolution, EShadowMapResolution.Medium),
         shadowBlur: types.Number("Shadow.Blur", 1),

--- a/libs/ff-scene/source/components/CRectLight.ts
+++ b/libs/ff-scene/source/components/CRectLight.ts
@@ -12,8 +12,8 @@ export default class CRectLight extends CLight
     static readonly typeName: string = "CRectLight";
 
     protected static readonly rectLightIns = {
-        position: types.Vector3("Light.Position", [ 0, 1, 0 ]),
-        target: types.Vector3("Light.Target", [ 0, 0, 0 ]),
+        position: types.Vector3("Light.Position", [ 0, 0, 0 ]),
+        target: types.Vector3("Light.Target", [ 0, -1, 0 ]),
         size: types.Vector2("Light.Size", [10, 10]),
     };
 
@@ -24,7 +24,10 @@ export default class CRectLight extends CLight
         super(node, id);
 
         this.object3D = new RectAreaLight();
-        
+        this.light.width = 1;
+        this.light.height = 1;
+        this.object3D.matrixAutoUpdate = false;
+        this.transform.ins.scale.addEventListener("value",this.update, this);
     }
 
     get light(): RectAreaLight {
@@ -40,10 +43,18 @@ export default class CRectLight extends CLight
 
         if (ins.position.changed || ins.target.changed) {
             light.position.fromArray(ins.position.value);
+            light.lookAt(new Vector3().fromArray(ins.target.value));
             light.updateMatrix();
         }
-
+        //RectAreaLight's size ignores scaling
+        this.light.width = this.transform.ins.scale.value[0]*10;
+        this.light.height = this.transform.ins.scale.value[2]*10;
 
         return true;
+    }
+
+    dispose(){
+        super.dispose();
+        this.transform.ins.scale.removeEventListener("value",this.update);
     }
 }

--- a/libs/ff-scene/source/components/CSpotLight.ts
+++ b/libs/ff-scene/source/components/CSpotLight.ts
@@ -20,9 +20,16 @@ export default class CSpotLight extends CLight
     protected static readonly spotLightIns = {
         position: types.Vector3("Light.Position"),
         target: types.Vector3("Light.Target", [ 0, -1, 0 ]),
-        distance: types.Number("Light.Distance"),
+        distance: types.Number("Light.Distance", {
+            preset: 0,
+            min: 0
+        }),
         decay: types.Number("Light.Decay", 1),
-        angle: types.Number("Light.Angle", 45),
+        angle: types.Number("Light.Angle", {
+            preset:45,
+            min: 0,
+            max: 89
+        }),
         penumbra: types.Percent("Light.Penumbra", 0.5),
     };
 

--- a/libs/ff-three/source/Axes.ts
+++ b/libs/ff-three/source/Axes.ts
@@ -1,0 +1,125 @@
+/**
+ * FF Typescript Foundation Library
+ * Copyright 2020 Ralph Wiedemeier, Frame Factory GmbH
+ *
+ * License: MIT
+ */
+
+import {
+  Object3D,
+  Vector3,
+  Matrix4,
+  Box3,
+  Color,
+  Material,
+  BufferGeometry,
+  Float32BufferAttribute,
+  Points,
+  PointsMaterial,
+} from "three";
+
+import { LineSegments2 } from "three/examples/jsm/lines/LineSegments2";
+import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
+import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
+
+import { computeLocalBoundingBox } from "./helpers";
+
+////////////////////////////////////////////////////////////////////////////////
+
+export interface IAxesProps
+{
+  /** 
+   * Color of the bracket lines. Default is to use color-coded xyz axes
+   * If four colors are provided, the first one will be used to show the origin point
+   */
+  colors?: [Color, Color, Color]| [Color, Color, Color, Color];
+  /** Length of the bracket lines relative to the size of the object. Default is 0.25. */
+  length?: number;
+  width?:number;
+  depthTest?: boolean,
+}
+
+/**
+* Wireframe selection bracket.
+*/
+export default class Axes extends LineSegments2
+{
+  static readonly defaultProps = {
+      length: 0.25,
+      width: 2,
+      depthTest: false,
+      colors: [new Color(0xffd633), new Color(0xa63b4a), new Color(0x6fa21c), new Color(0x2f83e1)],
+  };
+
+  private originPoint?:Points;
+
+  constructor(target: Object3D, props?: IAxesProps)
+  {
+      props = Object.assign({}, Axes.defaultProps, props);
+
+      const box = new Box3();
+      box.makeEmpty();
+
+      computeLocalBoundingBox(target, box);
+
+      const length = props.length;
+
+      const originColor :Color = props.colors.length === 4? props.colors[0]: null;
+
+      let vertices :number[] = [
+          0, 0, 0,	length, 0, 0,
+          0, 0, 0,	0, length, 0,
+          0, 0, 0,	0, 0, length,
+      ];
+
+
+      let colors :number[] = [];
+      for(let color of props.colors.slice(-3)){
+        let a = color.toArray();
+        colors.push(...a, ...a);
+      }
+
+      const geometry = new LineSegmentsGeometry();
+      geometry.setPositions(vertices);
+      geometry.setColors(colors);
+
+      const material = new LineMaterial({
+          vertexColors: true,
+          toneMapped: false,
+          depthTest: props.depthTest,
+          worldUnits: false, //Disables size attenuation
+          linewidth: props.width,
+      });
+
+      super(geometry, material);
+
+      if(originColor){
+        const originGeometry = new BufferGeometry();
+        originGeometry.setAttribute('position', new Float32BufferAttribute([0, 0, 0], 3));
+        const originMaterial = new PointsMaterial({ 
+            size: props.width+1,
+            toneMapped: false,
+            color: originColor,
+            sizeAttenuation: false,
+            depthTest: props.depthTest
+        });
+        this.originPoint = new Points(originGeometry, originMaterial);
+        this.originPoint.renderOrder = 2;
+        this.add(this.originPoint);
+      }
+
+      this.renderOrder = 1;
+  }
+
+  dispose()
+  {
+      if(this.originPoint){
+          this.remove(this.originPoint);
+          this.originPoint.geometry.dispose();
+          (this.originPoint.material as Material).dispose();
+      }
+
+      this.geometry.dispose();
+      (this.material as Material).dispose();
+  }
+}

--- a/libs/ff-three/source/Axes.ts
+++ b/libs/ff-three/source/Axes.ts
@@ -109,6 +109,11 @@ export default class Axes extends LineSegments2
       }
 
       this.renderOrder = 1;
+      this.update();
+  }
+
+  update(){
+    
   }
 
   dispose()

--- a/libs/ff-three/source/Bracket.ts
+++ b/libs/ff-three/source/Bracket.ts
@@ -15,8 +15,6 @@ import {
     Matrix4,
     Box3,
     Color,
-    Points,
-    PointsMaterial,
     Material,
 } from "three";
 
@@ -65,16 +63,16 @@ export default class Bracket extends LineSegments
         let has_volume = isFinite(size[0]) && isFinite(size[1]) && isFinite(size[2])
         if ( has_volume && props.axes){
             vertices = [
-                0, 0, 0,	length, 0, 0,
-                0, 0, 0,	0, length, 0,
-                0, 0, 0,	0, 0, length,
+                0, 0, 0,	length, 0, 0,   0, 0, 0,
+                0, 0, 0,	0, length, 0,   0, 0, 0,
+                0, 0, 0,	0, 0, length,   0, 0, 0,
             ];
             colors = [
-                1, 0, 0,	1, 0.6, 0,
-                0, 1, 0,	0.6, 1, 0,
-                0, 0, 1,	0, 0.6, 1
+                .65, .23, .29,	.65, .23, .29, .65, .23, .29, 
+                .43, .63, .11,	.43, .63, .11,	.43, .63, .11,
+                .25, .3, .88,	.25, .3, .88,	.25, .3, .88,
 
-            ]
+            ];
         }else if(has_volume) {
             vertices = [
                 min[0], min[1], min[2], min[0] + size[0], min[1], min[2],
@@ -123,26 +121,11 @@ export default class Bracket extends LineSegments
         const material = new LineBasicMaterial({
             color: props.color,
             vertexColors: !!colors,
-            
+            toneMapped: false,
             depthTest: false
         });
 
         super(geometry, material);
-
-        // Origin, as in "geometry's internal (0,0,0) point". We generally don't need this?
-        // const originGeometry = new BufferGeometry();
-        // originGeometry.setAttribute('position', new Float32BufferAttribute([0, 0, 0], 3));
-        // const originMaterial = new PointsMaterial({ 
-        //     size: 3,
-        //     color: props.color,
-        //     sizeAttenuation: false,
-        //     depthTest: false
-        // });
-        // const originPoint = new Points(originGeometry, originMaterial);
-        // originPoint.renderOrder = 2;
-        // this.add(originPoint);
-
-
 
         this.renderOrder = 1;
     }

--- a/libs/ff-three/source/Bracket.ts
+++ b/libs/ff-three/source/Bracket.ts
@@ -130,6 +130,10 @@ export default class Bracket extends LineSegments
         this.renderOrder = 1;
     }
 
+    update(){
+        
+    }
+
     dispose()
     {
 

--- a/libs/ff-three/source/Bracket.ts
+++ b/libs/ff-three/source/Bracket.ts
@@ -17,6 +17,7 @@ import {
     Color,
     Points,
     PointsMaterial,
+    Material,
 } from "three";
 
 import { computeLocalBoundingBox } from "./helpers";
@@ -148,11 +149,9 @@ export default class Bracket extends LineSegments
 
     dispose()
     {
-        if (this.parent) {
-            this.parent.remove(this);
-        }
 
         this.geometry.dispose();
+        (this.material as Material).dispose();
     }
 
     protected static expandBoundingBox(object: Object3D, root: Object3D, box: Box3)

--- a/libs/ff-three/source/lights/AmbientLightHelper.ts
+++ b/libs/ff-three/source/lights/AmbientLightHelper.ts
@@ -1,0 +1,66 @@
+import { ColorRepresentation, MeshBasicMaterial, Mesh, Light, SpotLight, SphereGeometry, PointLight, HemisphereLight, AmbientLight, Object3D, OctahedronGeometry, Color, PlaneGeometry, DoubleSide, BufferGeometry } from "three";
+import LightHelper from "./LightHelper";
+
+import {Line2} from "three/examples/jsm/lines/Line2";
+import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
+import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
+import { LineSegments2 } from "three/examples/jsm/lines/LineSegments2";
+import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
+
+type SphereLight = AmbientLight|HemisphereLight;
+
+export default class AmbientLightHelper extends Object3D {
+  public readonly type = 'AmbientLightHelper';
+  light :SphereLight;
+
+  protected geometry :BufferGeometry;
+  protected upper :Mesh;
+  protected lower :Mesh;
+
+	constructor( light :SphereLight, size :number = 1) {
+
+		super();
+    this.light = light;
+    this.geometry =  new SphereGeometry( size/2, 8, 4, 0, Math.PI*2, 0, Math.PI/2 );
+    this.upper = new Mesh(
+     this.geometry,
+      new MeshBasicMaterial({
+        opacity: 0.4,
+        transparent: true,
+        toneMapped: false,
+        side: DoubleSide,
+      }),
+    );
+    this.upper.receiveShadow = false;
+    console.log("Color", light.color);
+    (this.upper.material as MeshBasicMaterial).color = light.color;
+    this.add(this.upper);
+
+    this.lower = new Mesh(
+      this.geometry,
+      new MeshBasicMaterial({
+        opacity: 0.4,
+        transparent: true,
+        toneMapped: false,
+        side: DoubleSide,
+      }),
+    );
+    this.lower.rotateX(Math.PI);
+    this.lower.updateMatrix();
+    (this.lower.material as MeshBasicMaterial).color = ("groundColor" in light)? light.groundColor as Color : light.color;
+    this.add(this.lower);
+    this.position.set(0, -1, 0);
+
+	}
+
+  update(){
+
+  }
+
+	dispose() {
+    this.geometry.dispose();
+    (this.upper.material as MeshBasicMaterial).dispose();
+    (this.lower.material as MeshBasicMaterial).dispose();
+	}
+
+}

--- a/libs/ff-three/source/lights/DirectionalLightHelper.ts
+++ b/libs/ff-three/source/lights/DirectionalLightHelper.ts
@@ -1,0 +1,57 @@
+import { Vector3, BufferGeometry, Line, ColorRepresentation, SpotLight, DirectionalLight, Light, LightShadow } from "three";
+import LightHelper from "./LightHelper";
+
+import {Line2} from "three/examples/jsm/lines/Line2";
+import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
+import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
+
+type TargetLight = Light & (DirectionalLight|SpotLight);
+
+export default class DirectionalLightHelper extends LightHelper {
+  public readonly type :string = 'DirectionalLightHelper';
+  light :TargetLight;
+
+  protected target :Line2;
+  protected targetMaterial :LineMaterial;
+
+	constructor( light :TargetLight, size ?:number) {
+
+		super(light, size);
+
+    this.targetMaterial = new LineMaterial({
+      opacity: 0.8,
+      transparent: true,
+      toneMapped: false,
+      depthTest: false, //Directional lights have no real "position" so there is no point in using depth
+      worldUnits: false,
+      
+      linewidth: 2,
+    });
+    this.targetMaterial.color = this.light.color;
+
+    this.target = new Line2(
+      new LineGeometry().setPositions([
+        0, 0, 0, ...light.target.position.toArray(),
+      ]),
+      this.targetMaterial
+    );
+    this.target.scale.setScalar(10);
+    this.target.matrixAutoUpdate = false;
+    this.add(this.target);
+	}
+
+  update(){
+    super.update();
+    if(this.light.castShadow){
+      this.target.scale.setScalar(this.light.shadow.camera.far- this.light.shadow.camera.near);
+      this.target.position.set( 0, -this.light.shadow.camera.near, 0);
+      this.target.updateMatrix();
+    }
+  }
+
+	dispose() {
+    this.target.geometry.dispose();
+    super.dispose();
+	}
+
+}

--- a/libs/ff-three/source/lights/LightHelper.ts
+++ b/libs/ff-three/source/lights/LightHelper.ts
@@ -1,0 +1,43 @@
+import { Object3D, ColorRepresentation, Material, MeshBasicMaterial,  Light, SphereGeometry, WireframeGeometry, LineSegments, LineBasicMaterial } from "three";
+
+
+
+
+export default class LightHelper extends Object3D {
+  public readonly type :string = 'LightHelper';
+  public light :Light;
+ 
+  protected material :LineBasicMaterial;
+  protected source :LineSegments;
+
+	constructor( light:Light, size :number = 1) {
+
+		super();
+
+		this.light = light;
+
+
+    this.material = new LineBasicMaterial({
+      opacity: 0.8,
+      transparent: true,
+      toneMapped: false,
+    });
+    this.material.color = this.light.color;
+
+    //Ponctual light indicator
+    this.source = new LineSegments(
+      new WireframeGeometry(new SphereGeometry(size/10, 8, 4)),
+      this.material,
+    );
+    this.add(this.source);
+  }
+
+  update(){
+  }
+
+	dispose() {
+    this.source.geometry.dispose();
+    this.material.dispose();
+	}
+
+}

--- a/libs/ff-three/source/lights/PointLightHelper.ts
+++ b/libs/ff-three/source/lights/PointLightHelper.ts
@@ -1,0 +1,40 @@
+import { MeshBasicMaterial, Mesh, SphereGeometry, PointLight } from "three";
+import LightHelper from "./LightHelper";
+
+
+export default class PointLightHelper extends LightHelper {
+  public readonly type = 'PointLightHelper';
+  light :PointLight;
+
+  protected distance :Mesh;
+
+	constructor( light :PointLight) {
+
+		super(light, 0.6);
+
+    this.distance = new Mesh(
+      new SphereGeometry(1),
+      new MeshBasicMaterial({
+        opacity: 0.15,
+        transparent: true,
+      }),
+    );
+    (this.distance.material as MeshBasicMaterial).color = light.color;
+    this.distance.matrixAutoUpdate = false;
+    this.add(this.distance);
+	}
+
+  update(){
+    super.update();
+    this.distance.scale.setScalar(this.light.distance);
+    this.distance.updateMatrix()
+
+  }
+
+	dispose() {
+    this.distance.geometry.dispose();
+    (this.distance.material as MeshBasicMaterial).dispose();
+    super.dispose();
+	}
+
+}

--- a/libs/ff-three/source/lights/RectLightHelper.ts
+++ b/libs/ff-three/source/lights/RectLightHelper.ts
@@ -1,0 +1,81 @@
+import {  BoxGeometry, FrontSide, Mesh, MeshBasicMaterial, Object3D, RectAreaLight } from "three";
+
+import {Line2} from "three/examples/jsm/lines/Line2";
+import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
+import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
+import { LineSegments2 } from "three/examples/jsm/lines/LineSegments2";
+import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
+
+
+export default class RectLightHelper extends Object3D {
+  public readonly type :string = 'RectLightHelper';
+  light :RectAreaLight;
+
+  protected lines :LineSegments2;
+  protected area :Mesh;
+
+	constructor( light :RectAreaLight) {
+
+		super();
+    this.light = light;
+    const material = new LineMaterial({
+      opacity: 0.8,
+      transparent: true,
+      toneMapped: false,
+      worldUnits: false,
+      
+      linewidth: 2,
+    });
+    material.color = this.light.color;
+
+    this.lines = new LineSegments2(
+      new LineSegmentsGeometry().setPositions([
+        0, 0, 0,        0, 0, -1,
+        5, -5, 0,     5, 5, 0,
+        5, 5, 0,      -5, 5, 0,
+        -5, 5, 0,     -5, -5, 0,
+        -5, -5, 0,    5, -5, 0,
+      ]),
+      material
+    );
+    this.add(this.lines);
+
+    const boxMats = [
+      null, null, null, null,
+      new MeshBasicMaterial({
+        opacity: 0.1, //Back side
+        transparent: true,
+        toneMapped: false,
+        side: FrontSide,
+      }),
+      new MeshBasicMaterial({
+        opacity: 0.4, //Front side
+        transparent: true,
+        toneMapped: false,
+        side: FrontSide,
+      }),
+    ];
+    boxMats[4].color = boxMats[5].color = light.color;
+
+    this.area = new Mesh(
+      new BoxGeometry(light.width, light.height, 0),
+      boxMats,
+    )
+    this.add(this.area)
+	}
+
+  update(){
+
+  }
+
+	dispose() {
+    this.lines.geometry.dispose();
+    this.area.geometry.dispose();
+
+    (this.lines.material as LineMaterial).dispose();
+    let mats = (this.area.material as MeshBasicMaterial[]);
+    mats[4].dispose();
+    mats[5].dispose();
+	}
+
+}

--- a/libs/ff-three/source/lights/SpotLightHelper.ts
+++ b/libs/ff-three/source/lights/SpotLightHelper.ts
@@ -1,0 +1,43 @@
+import { ColorRepresentation, SpotLight, WireframeGeometry, LineSegments, ConeGeometry } from "three";
+
+import DirectionalLightHelper from "./DirectionalLightHelper";
+
+
+
+export default class SpotLightHelper extends DirectionalLightHelper {
+  public readonly type = 'SpotLightHelper';
+  light :SpotLight;
+
+  protected cone :LineSegments;
+
+	constructor( light :SpotLight) {
+
+		super(light as any, 0.6);
+    this.targetMaterial.depthTest = true;
+
+
+    this.cone = new LineSegments(
+      new WireframeGeometry(new ConeGeometry(1, 1, 16, 1, true)),
+      this.material,
+    );
+    this.cone.matrixAutoUpdate = false;
+    this.cone.position.set(0, -0.5*length, 0);
+    this.cone.updateMatrix();
+    this.add(this.cone);
+	}
+
+  update(){
+    let length = this.light.distance || 10;
+    let r = Math.min(Math.tan(this.light.angle), 1000)*length;
+    this.cone.scale.set(r, length, r);
+    this.cone.position.set(0, -0.5*length, 0);
+    this.cone.updateMatrix();
+    super.update()
+  }
+
+	dispose() {
+    this.cone.geometry.dispose();
+    super.dispose();
+	}
+
+}

--- a/source/client/components/CVPoseTask.ts
+++ b/source/client/components/CVPoseTask.ts
@@ -84,6 +84,7 @@ export default class CVPoseTask extends CVTask
         configuration.annotationsVisible = false;
         configuration.interfaceVisible = false;
         configuration.bracketsVisible = true;
+        configuration.axesVisible = true;
     }
 
     protected get renderer() {

--- a/source/client/components/CVTask.ts
+++ b/source/client/components/CVTask.ts
@@ -22,10 +22,20 @@ import CVNodeObserver from "./CVNodeObserver";
 import CVDocument from "./CVDocument";
 
 import NodeView, { customElement, property, html } from "../ui/explorer/NodeView";
+import Property from "@ff/graph/Property";
+import CVDocumentProvider from "./CVDocumentProvider";
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export { types, customElement, property, html };
+
+export interface CVTaskConfiguration{
+    bracketsVisible?: boolean,
+    interfaceVisible?: boolean,
+    gridVisible?: boolean,
+    annotationsVisible?: boolean,
+    axesVisible?: boolean,
+}
 
 /**
  * Base class for tasks in the Voyager Story authoring environment. A task provides a number of tools. The tools operate
@@ -59,14 +69,14 @@ export default class CVTask extends CVNodeObserver
 
     private _isActiveTask = false;
 
-    protected configuration = {
+    protected configuration :CVTaskConfiguration = {
         bracketsVisible: undefined,
         interfaceVisible: undefined,
         gridVisible: undefined,
         annotationsVisible: undefined,
     };
 
-    private _savedConfig = {
+    private _savedConfig :CVTaskConfiguration = {
         bracketsVisible: undefined,
         interfaceVisible: undefined,
         gridVisible: undefined,
@@ -95,13 +105,16 @@ export default class CVTask extends CVNodeObserver
         this._isActiveTask = true;
 
         this.outs.isActive.setValue(true);
-
         const configuration = this.configuration;
         const savedConfig = this._savedConfig;
-
-        if (configuration.bracketsVisible !== undefined) {
+        if (typeof configuration.bracketsVisible !== "undefined") {
             const prop = this.selection.ins.viewportBrackets;
             savedConfig.bracketsVisible = prop.value;
+            prop.setValue(!!configuration.bracketsVisible);
+        }
+        if(typeof configuration.axesVisible !== "undefined"){
+            const prop = this.selection.ins.viewportAxes;
+            savedConfig.axesVisible = prop.value;
             prop.setValue(!!configuration.bracketsVisible);
         }
     }
@@ -113,8 +126,11 @@ export default class CVTask extends CVNodeObserver
     {
         const savedConfig = this._savedConfig;
 
-        if (savedConfig.bracketsVisible !== undefined) {
+        if (typeof savedConfig.bracketsVisible !== "undefined") {
             this.selection.ins.viewportBrackets.setValue(savedConfig.bracketsVisible);
+        }
+        if(typeof savedConfig.axesVisible !== "undefined"){
+            this.selection.ins.viewportAxes.setValue(savedConfig.axesVisible);
         }
 
         this._isActiveTask = false;


### PR DESCRIPTION
My initial goal was to provide a visual indicator for an object's current pivot point when brackets are shown.

While I was at it I improved the style of the various light helpers. to have a more distinctive look. It should make it easier to visually identify a light type and know how it will affect the scene by looking at its viewport helper.

I ended up rewriting the brackets/helpers rendering code because I couldn't get rid of some positioning and synchronization inconsistencies otherwise. I like the new system though, it saves a render pass. I did not test whether it improved performance but it shouldn't hurt.

I took the opportunity to narrow down some property constraints where possible (mainly `min: 0` where negative values wouldn't make sense).

All light types should now be usable and easy-enough to configure with the visual helpers, they just lack some UI elements to add/remove lights from a scene, for which I will have a PR coming real soon.
