### PR TITLE
prevent interacting with linked Property

### DIFF
--- a/source/client/ui/explorer/styles.scss
+++ b/source/client/ui/explorer/styles.scss
@@ -1211,7 +1211,11 @@ $tour-entry-indent: 12px;
 ////////////////////////////////////////////////////////////////////////////////
 // PROPERTIES
 .sv-property{
-
+  &[disabled]{
+    cursor: default;
+    filter: brightness(0.6);
+    pointer-events: none;
+  }
 
   .ff-input{
     min-width: auto;

--- a/source/client/ui/story/PropertyView.ts
+++ b/source/client/ui/story/PropertyView.ts
@@ -68,32 +68,33 @@ export default class PropertyView extends CustomElement
         const property = this.property;
         const schema = property.schema;
         const label = this.label !== undefined ? this.label : property.path.split(".").pop();
-
+        let linked = this.property.hasMainInLinks();
         if(property.isArray() && property.type !== "number"){
             console.error("Unsupported property : ", property);
             return null;
         }
-
         if(property.type === "number" && property.schema.semantic === "color"){
-            return html`<sv-property-color name=${label} .property=${property}></sv-property-color>`;
+            return html`<sv-property-color ?disabled=${linked} name=${label} .property=${property}></sv-property-color>`;
         }else if (property.type === "number" && property.isArray()) {
             let fields = [];
             for (let i = 0; i < property.elementCount; ++i) {
+                
+                let index_linked = linked || this.property.hasInLinks(i);
                 const fieldLabel = property.schema.labels?.[i] ?? _defaultLabels[i];
-                fields.push(html`<sv-property-number name=${fieldLabel} .index=${i} .property=${property}></sv-property-number>`);
+                fields.push(html`<sv-property-number ?disabled=${index_linked} name=${fieldLabel} .index=${i} .property=${property}></sv-property-number>`);
             }
             const headerElement = label ? html`<div class="sv-property-name">${label}</div>` : null;
             return html`${headerElement}<div class="sv-property-group">${fields}</div>`;
         }else if (schema.event) {
-            return html`<sv-property-event name=${label} .property=${property}></sv-property-event>`;
+            return html`<sv-property-event ?disabled=${linked} name=${label} .property=${property}></sv-property-event>`;
         }else if (schema.options) {
-            return html`<sv-property-options dropdown name=${label} .property=${property}></sv-property-options>`;
+            return html`<sv-property-options ?disabled=${linked} dropdown name=${label} .property=${property}></sv-property-options>`;
         }else if(property.type === "boolean"){
-            return html`<sv-property-boolean name=${label} .property=${property}></sv-property-boolean>`;
+            return html`<sv-property-boolean ?disabled=${linked} name=${label} .property=${property}></sv-property-boolean>`;
         }else if(property.type === "string"){
-            return html`<sv-property-string name=${label} .property=${property}></sv-property-string>`
+            return html`<sv-property-string ?disabled=${linked} name=${label} .property=${property}></sv-property-string>`
         }else if(property.type === "number"){
-            return html`<sv-property-number name=${label} .property=${property}></sv-property-number>`
+            return html`<sv-property-number ?disabled=${linked} name=${label} .property=${property}></sv-property-number>`
         }else{
             console.warn("Unhandled property :", property.name);
             return html`<div class="sv-property-name">${label}</div><div class="sv-property-group">${property.value} (not editable)</div>`;


### PR DESCRIPTION
Continuing my crusade against broken data bindings.

Properties that have their values linked from another prop should probably not be interactive.

Because the link is unidirectional, the value change is not propagated and it leads to inconsistencies.

The only case where this is currently visible is with the Lights transform, when `lightsFollowCam` is enabled. If I change this value, it's ignored the next time I move the camera.

This is a very minor annoyance but if this gets merged I intend to use such a binding to control the **transform** inputs of **CVCamera**, thus allowing the camera's transform setting to be locked-up, fixing #314.


See https://github.com/Smithsonian/dpo-voyager/commit/4bab99f17e9f7fee4ac8995444e7f19c4c088a43 for changes that would be required to link Cameras transform from CVOrbitNavigation.