### PR TITLE
deduplicate models bounding box computation

### DIFF
--- a/source/client/io/ModelReader.ts
+++ b/source/client/io/ModelReader.ts
@@ -133,8 +133,6 @@ export default class ModelReader
                    material.map.colorSpace = SRGBColorSpace;
                 }
 
-                mesh.geometry.computeBoundingBox();
-
                 const uberMat = material.type === "MeshPhysicalMaterial" ? new UberPBRAdvMaterial() : new UberPBRMaterial();
 
                 if (material.flatShading) {


### PR DESCRIPTION
Specifically [BufferGeometry.computeBoundingBox](https://threejs.org/docs/?q=Mesh#api/en/core/BufferGeometry.computeBoundingBox), which sets `BufferGeometry.boundingBox`, looks like it is not used anywhere.

The code uses [computeLocalBoundingBox](https://github.com/Smithsonian/dpo-voyager/blob/dff5bcf0425c2c4b0ec79c0ed3ef8afc2b30d793/libs/ff-three/source/helpers.ts#L106), using more or less the same algorithm but with additional tree traversal and matrix composition logic.

fwiw, each of those can take up to 100ms to compute on large-ish models so it can add up quickly. Ideally i'd totally skip this if the box can be retrived from the svx document or at least compute only the **Thumb** model's box and roll with it, but that'd be a more substantial change for another time.