### PR TITLE
Eliminate forced reflows when rendering HTMLSprites

### DIFF
--- a/libs/ff-three/source/HTMLSprite.ts
+++ b/libs/ff-three/source/HTMLSprite.ts
@@ -106,7 +106,7 @@ export default class HTMLSprite<EventMap extends Object3DEventMap = Object3DEven
      * @param anchor The 3D object to which the HTML sprite element is attached.
      * @param offset An offset to be added to the anchor 3D object.
      */
-    renderHTMLElement(element: SpriteElement, container: HTMLElement, camera: Camera, anchor?: Object3D, offset?: Vector3)
+    renderHTMLElement(element: SpriteElement, bounds: DOMRect, camera: Camera, anchor?: Object3D, offset?: Vector3)
     {
         anchor = anchor || this;
 
@@ -127,9 +127,8 @@ export default class HTMLSprite<EventMap extends Object3DEventMap = Object3DEven
         _vec2b.set(_vec3b.x, _vec3b.y);
         _vec2a.set(_vec3a.x, _vec3a.y);
         _vec2b.sub(_vec2a);
-
-        const x = (_vec3b.x + 1) * 0.5 * container.clientWidth;
-        const y = (1 - _vec3b.y) * 0.5 * container.clientHeight;
+        const x = (_vec3b.x + 1) * 0.5 * bounds.width;
+        const y = (1 - _vec3b.y) * 0.5 * bounds.height;
 
         element.setPosition(x, y);
 

--- a/libs/ff-three/source/HTMLSpriteGroup.ts
+++ b/libs/ff-three/source/HTMLSpriteGroup.ts
@@ -16,6 +16,14 @@ import HTMLSprite from "./HTMLSprite";
 
 export { HTMLSprite };
 
+interface IViewport{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    overlay: HTMLElement;
+}
+
 /**
  * THREE 3D object, grouping a number of HTML sprites.
  */
@@ -69,13 +77,14 @@ export default class HTMLSpriteGroup extends Object3D
      * @param container HTML container element for the HTML elements.
      * @param camera The camera used to render the 3D scene.
      */
-    render(container: HTMLElement, camera: Camera)
+    render(container :HTMLElement, camera: Camera)
     {
         if (!this.visible) {
             return;
         }
         //Only get bounds once to prevent forced reflows while looping
         const bounds = container.getBoundingClientRect();
+
         const children = this.children as HTMLSprite[];
         for (let i = 0, n = children.length; i < n; ++i) {
             const child = children[i];

--- a/libs/ff-three/source/HTMLSpriteGroup.ts
+++ b/libs/ff-three/source/HTMLSpriteGroup.ts
@@ -74,13 +74,14 @@ export default class HTMLSpriteGroup extends Object3D
         if (!this.visible) {
             return;
         }
-
+        //Only get bounds once to prevent forced reflows while looping
+        const bounds = container.getBoundingClientRect();
         const children = this.children as HTMLSprite[];
         for (let i = 0, n = children.length; i < n; ++i) {
             const child = children[i];
             const element = child.getHTMLElement(container);
             if (element) {
-                child.renderHTMLElement(element, container, camera);
+                child.renderHTMLElement(element, bounds, camera);
             }
         }
     }

--- a/source/client/annotations/CircleSprite.ts
+++ b/source/client/annotations/CircleSprite.ts
@@ -87,9 +87,9 @@ export default class CircleSprite extends AnnotationSprite
         super.update();
     }
 
-    renderHTMLElement(element: AnnotationElement, container: HTMLElement, camera: UniversalCamera)
+    renderHTMLElement(element: AnnotationElement, bounds: DOMRect, camera: UniversalCamera)
     {
-        super.renderHTMLElement(element, container, camera, this.anchorMesh, _offset);
+        super.renderHTMLElement(element, bounds, camera, this.anchorMesh, _offset);
 
         // Override viewAngle calculation using temporary offset
         const anchor = this.anchorMesh;
@@ -140,7 +140,7 @@ export default class CircleSprite extends AnnotationSprite
                     element.requestUpdate().then(() => {
                         this.originalHeight = element.offsetHeight;
                         this.originalWidth = element.offsetWidth;
-                        this.checkTruncate(element, container);
+                        this.checkTruncate(element, bounds);
                     });
                 }
                 else {
@@ -149,7 +149,7 @@ export default class CircleSprite extends AnnotationSprite
                 }
             }
 
-            this.checkTruncate(element, container);
+            this.checkTruncate(element, bounds);
         }
     }
 
@@ -159,40 +159,40 @@ export default class CircleSprite extends AnnotationSprite
     }
 
     // Helper function to check if annotation should truncate
-    protected checkTruncate(element: AnnotationElement, container: HTMLElement) {
-        const x = element.getBoundingClientRect().left - container.getBoundingClientRect().left;
-        const y = element.getBoundingClientRect().top - container.getBoundingClientRect().top;
+    protected checkTruncate(element: AnnotationElement, bounds: DOMRect) {
+        const x = element.getBoundingClientRect().left - bounds.left;
+        const y = element.getBoundingClientRect().top - bounds.top;
 
-        const shouldTruncate = y + this.originalHeight >= container.offsetHeight;
+        const shouldTruncate = y + this.originalHeight >= bounds.height;
         if(shouldTruncate !== element.truncated) {
             element.truncated = shouldTruncate;
             element.requestUpdate().then(() => {
-                this.checkBounds(element, container);
+                this.checkBounds(element, bounds);
             });
         }
         else {
-            this.checkBounds(element, container);
+            this.checkBounds(element, bounds);
         }
     }
 
     // Helper function to check and handle annotation overlap with bounds of container
-    protected checkBounds(element: AnnotationElement, container: HTMLElement) {
-        const x = element.getBoundingClientRect().left - container.getBoundingClientRect().left;
-        const y = element.getBoundingClientRect().top - container.getBoundingClientRect().top;
+    protected checkBounds(element: AnnotationElement, bounds: DOMRect) {
+        const x = element.getBoundingClientRect().left - bounds.left;
+        const y = element.getBoundingClientRect().top - bounds.top;
 
-        if (x + element.offsetWidth >= container.offsetWidth && !element.classList.contains("sv-align-right")) {
+        if (x + element.offsetWidth >= bounds.width && !element.classList.contains("sv-align-right")) {
             element.classList.add("sv-align-right");
             element.requestUpdate();
         }
-        else if (x + element.offsetWidth < container.offsetWidth && element.classList.contains("sv-align-right")){
+        else if (x + element.offsetWidth < bounds.width && element.classList.contains("sv-align-right")){
             element.classList.remove("sv-align-right");
             element.requestUpdate();
         }
-        if (y + element.offsetHeight >= container.offsetHeight && !element.classList.contains("sv-align-bottom")) {
+        if (y + element.offsetHeight >= bounds.height && !element.classList.contains("sv-align-bottom")) {
             element.classList.add("sv-align-bottom");
             element.requestUpdate();
         }
-        else if (y + element.offsetHeight < container.offsetHeight && element.classList.contains("sv-align-bottom")) {
+        else if (y + element.offsetHeight < bounds.height && element.classList.contains("sv-align-bottom")) {
             element.classList.remove("sv-align-bottom");
             element.requestUpdate();
         }

--- a/source/client/annotations/ExtendedSprite.ts
+++ b/source/client/annotations/ExtendedSprite.ts
@@ -78,9 +78,9 @@ export default class ExtendedSprite extends AnnotationSprite
         super.update();
     }
 
-    renderHTMLElement(element: ExtendedAnnotation, container: HTMLElement, camera: Camera)
+    renderHTMLElement(element: ExtendedAnnotation, bounds: DOMRect, camera: Camera)
     {
-        super.renderHTMLElement(element, container, camera, this.stemLine, _offset);
+        super.renderHTMLElement(element, bounds, camera, this.stemLine, _offset);
 
         const angleOpacity = math.scaleLimit(this.viewAngle * math.RAD2DEG, 90, 100, 1, 0);
         const opacity = this.annotation.data.visible ? angleOpacity : 0;
@@ -121,7 +121,7 @@ export default class ExtendedSprite extends AnnotationSprite
                     element.requestUpdate().then(() => {
                         this.originalHeight = element.offsetHeight;
                         this.originalWidth = element.offsetWidth;
-                        this.checkTruncate(element, container);
+                        this.checkTruncate(element, bounds);
                     });
                     return;
                 }
@@ -131,7 +131,7 @@ export default class ExtendedSprite extends AnnotationSprite
                 }
             }
 
-            this.checkTruncate(element, container);     
+            this.checkTruncate(element, bounds);
         }
     }
 
@@ -141,16 +141,15 @@ export default class ExtendedSprite extends AnnotationSprite
     }
 
     // Helper function to check if annotation should truncate
-    protected checkTruncate(element: AnnotationElement, container: HTMLElement) {
+    protected checkTruncate(element: AnnotationElement, bounds: DOMRect) {
         const top = this.quadrant == EQuadrant.TopLeft || this.quadrant == EQuadrant.TopRight;
         const right = this.quadrant == EQuadrant.TopRight || this.quadrant == EQuadrant.BottomRight;
-        const x = right ? element.getBoundingClientRect().left - container.getBoundingClientRect().left
-            : element.getBoundingClientRect().right - container.getBoundingClientRect().left;
-        const y = top ? element.getBoundingClientRect().bottom - container.getBoundingClientRect().top 
-            : element.getBoundingClientRect().top - container.getBoundingClientRect().top;
-
-        const shouldTruncateVert = !top ? y + this.originalHeight >= container.offsetHeight : y - this.originalHeight <= 0;
-        const shouldTruncateHoriz = right ? x + this.originalWidth >= container.offsetWidth : x - this.originalWidth <= 0;
+        const x = right ? element.getBoundingClientRect().left - bounds.left
+            : element.getBoundingClientRect().right - bounds.left;
+        const y = top ? element.getBoundingClientRect().bottom - bounds.top 
+            : element.getBoundingClientRect().top - bounds.top;
+        const shouldTruncateVert = !top ? y + this.originalHeight >= bounds.height : y - this.originalHeight <= 0;
+        const shouldTruncateHoriz = right ? x + this.originalWidth >= bounds.width : x - this.originalWidth <= 0;
         const shouldTruncate = shouldTruncateVert || shouldTruncateHoriz;
         if(shouldTruncate !== element.truncated) {
             element.truncated = shouldTruncate;

--- a/source/client/annotations/StandardSprite.ts
+++ b/source/client/annotations/StandardSprite.ts
@@ -74,9 +74,9 @@ export default class StandardSprite extends AnnotationSprite
         super.update();
     }
 
-    renderHTMLElement(element: StandardAnnotation, container: HTMLElement, camera: Camera)
+    renderHTMLElement(element: StandardAnnotation, bounds: DOMRect, camera: Camera)
     {
-        super.renderHTMLElement(element, container, camera, this.stemLine, _offset);
+        super.renderHTMLElement(element, bounds, camera, this.stemLine, _offset);
 
         const angleOpacity = math.scaleLimit(this.viewAngle * math.RAD2DEG, 90, 100, 1, 0);
         const opacity = this.annotation.data.visible ? angleOpacity : 0;


### PR DESCRIPTION
`HTMLSprite.renderHTMLElement` and `HTMLSpriteGroup.render` were causing unnecessary forced reflows within their render loops.

skipping `getBoundingClientRect()` where possible solves it.

Basically free performance gain, about .5 ms per annotation.