### PR TITLE
make evaluateProps reentrant in all applications

### DIFF
--- a/source/client/applications/ExplorerApplication.ts
+++ b/source/client/applications/ExplorerApplication.ts
@@ -261,7 +261,7 @@ Version: ${ENV_VERSION}
 
     evaluateProps()
     {
-        const props = this.props;
+        const props = {...this.props};
         const manager = this.assetManager;
         const qs = new URL(window.location.href).searchParams;
         props.root = props.root || qs.get("root") || qs.get("r");

--- a/source/client/applications/MiniApplication.ts
+++ b/source/client/applications/MiniApplication.ts
@@ -171,7 +171,7 @@ export default class MiniApplication
 
     evaluateProps()
     {
-        const props = this.props;
+        const props = {...this.props};
         const manager = this.assetManager;
 
         const qs = new URL(window.location.href).searchParams;

--- a/source/client/applications/StoryApplication.ts
+++ b/source/client/applications/StoryApplication.ts
@@ -141,7 +141,7 @@ export default class StoryApplication
 
     protected evaluateProps()
     {
-        const props = this.props;
+        const props = {...this.props};
 
         const qs = new URL(window.location.href).searchParams;
         props.referrer = props.referrer || qs.get("referrer");


### PR DESCRIPTION
`ExplorerApplication.evaluateProps()` won't yield the same result when run twice, because `const props = this.props` only references the original object, so down the line when we get the queryString values, it changes the values stored in `this.props`, thus potentially changing the result of `evaluateProps()` in unexpected ways.

I think we should keep `this.props` unchanged or make it clear we intend to modify it by removing the `const props = this.props` assignment.

I prefer the first solution as it's a one-line change and allows calling evaluateProps after a change in the page's queryString.