### PR TITLE
Dynamic LOD switching

### DIFF
--- a/libs/ff-graph/source/components/CPulse.ts
+++ b/libs/ff-graph/source/components/CPulse.ts
@@ -19,6 +19,8 @@ export interface IPulseContext extends IUpdateContext
     secondsElapsed: number;
     secondsDelta: number;
     frameNumber: number;
+    tickUpdated: boolean;
+    tockUpdated: boolean;
 }
 
 /**
@@ -53,7 +55,6 @@ export default class CPulse extends Component
     private _secondsStopped: number;
     private _animHandler: number;
     private _pulseEvent: IPulseEvent;
-    private _tockUpdated = false;
 
     constructor(node: Node, id: string)
     {
@@ -66,7 +67,9 @@ export default class CPulse extends Component
             time: new Date(),
             secondsElapsed: 0,
             secondsDelta: 0,
-            frameNumber: 0
+            frameNumber: 0,
+            tickUpdated: false,
+            tockUpdated: false,
         };
 
         this._secondsStarted = Date.now() * 0.001;
@@ -118,14 +121,14 @@ export default class CPulse extends Component
         outs.frame.setValue(context.frameNumber);
 
         // execute tick
-        const tickUpdated = this.system.graph.tick(context);
+        context.tickUpdated = this.system.graph.tick(context);
 
         // emit pulse event
-        _pulseEvent.systemUpdated = tickUpdated || this._tockUpdated;
+        _pulseEvent.systemUpdated = context.tickUpdated || context.tockUpdated;
         this.emit<IPulseEvent>(_pulseEvent);
 
         // execute tock
-        this._tockUpdated = this.system.graph.tock(context);
+        context.tockUpdated = this.system.graph.tock(context);
     }
 
     protected onAnimationFrame()

--- a/libs/ff-scene/source/components/CRenderer.ts
+++ b/libs/ff-scene/source/components/CRenderer.ts
@@ -6,7 +6,7 @@
  */
 
 import { Mesh } from "three";
-import * as constants from "three/src/constants";
+import * as constants from "three/src/constants.js";
 
 import Component, { Node, ITypedEvent, types } from "@ff/graph/Component";
 import CPulse, { IPulseEvent } from "@ff/graph/components/CPulse";
@@ -66,6 +66,7 @@ export default class CRenderer extends Component
     static readonly outs = {
         maxTextureSize: types.Integer("Caps.MaxTextureSize"),
         maxCubemapSize: types.Integer("Caps.MaxCubemapSize"),
+        framerate: types.Integer("Renderer.Framerate"),
     };
 
     ins = this.addInputs(CRenderer.ins);
@@ -221,7 +222,9 @@ export default class CRenderer extends Component
 
             this.views.forEach(view => {
                 if(!view.renderer.xr.isPresenting) {
+                    const start = (performance || Date).now();
                     view.render();
+                    this.outs.framerate.value = this.outs.framerate.value *0.9 + 0.1*1000/((performance || Date).now() -start);
                 }
             });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,9 +214,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
         },
         "node_modules/@types/html-minifier-terser": {
             "version": "6.0.0",
@@ -236,9 +236,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.18.108",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.108.tgz",
-            "integrity": "sha512-fj42LD82fSv6yN9C6Q4dzS+hujHj+pTv0IpRR3kI20fnYeS0ytBpjFO9OjmDowSPPt4lNKN46JLaKbCyP+BW2A=="
+            "version": "16.18.122",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.122.tgz",
+            "integrity": "sha512-rF6rUBS80n4oK16EW8nE75U+9fw0SSUgoPtWSvHhPXdT7itbvmS7UjB/jyM8i3AkvI6yeSM5qCwo+xN0npGDHg=="
         },
         "node_modules/@types/stats.js": {
             "version": "0.17.2",
@@ -2378,18 +2378,6 @@
                 "handlebars": ">= 1.3.0 < 5"
             }
         },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2694,12 +2682,15 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "node_modules/is-core-module": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+            "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
             "dev": true,
             "dependencies": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3284,12 +3275,12 @@
             "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "node_modules/mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
             "dependencies": {
-                "minimist": "^1.2.5"
+                "minimist": "^1.2.6"
             },
             "bin": {
                 "mkdirp": "bin/cmd.js"
@@ -4518,9 +4509,9 @@
             "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
             }
@@ -4765,13 +4756,17 @@
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
         },
         "node_modules/resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "version": "1.22.9",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
+            "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
+                "is-core-module": "^2.16.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5542,6 +5537,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/svgo": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -5838,9 +5845,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -6675,9 +6682,9 @@
             }
         },
         "@types/estree": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-            "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
         },
         "@types/html-minifier-terser": {
             "version": "6.0.0",
@@ -6697,9 +6704,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "16.18.108",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.108.tgz",
-            "integrity": "sha512-fj42LD82fSv6yN9C6Q4dzS+hujHj+pTv0IpRR3kI20fnYeS0ytBpjFO9OjmDowSPPt4lNKN46JLaKbCyP+BW2A=="
+            "version": "16.18.122",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.122.tgz",
+            "integrity": "sha512-rF6rUBS80n4oK16EW8nE75U+9fw0SSUgoPtWSvHhPXdT7itbvmS7UjB/jyM8i3AkvI6yeSM5qCwo+xN0npGDHg=="
         },
         "@types/stats.js": {
             "version": "0.17.2",
@@ -8266,15 +8273,6 @@
                 "object-assign": "^4.1.0"
             }
         },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
-        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -8481,12 +8479,12 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-core-module": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-            "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+            "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
             "dev": true,
             "requires": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.2"
             }
         },
         "is-extglob": {
@@ -8940,12 +8938,12 @@
             "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
             "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "^1.2.6"
             }
         },
         "mocha": {
@@ -9791,9 +9789,9 @@
             "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
         },
         "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "qs": {
             "version": "6.13.0",
@@ -9969,13 +9967,14 @@
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
         },
         "resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "version": "1.22.9",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
+            "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
             "dev": true,
             "requires": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
+                "is-core-module": "^2.16.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
             }
         },
         "resolve-cwd": {
@@ -10528,6 +10527,12 @@
                 "has-flag": "^3.0.0"
             }
         },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true
+        },
         "svgo": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -10730,9 +10735,9 @@
             }
         },
         "typescript": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true
         },
         "typescript-json-schema": {

--- a/source/client/applications/coreTypes.ts
+++ b/source/client/applications/coreTypes.ts
@@ -81,6 +81,7 @@ import NVNode from "../nodes/NVNode";
 import CVAmbientLight from "client/components/lights/CVAmbientLight";
 import CVHemisphereLight from "client/components/lights/CVHemisphereLight";
 import CVRectLight from "client/components/lights/CVRectLight";
+import CVDerivativesController from "client/components/CVDerivativesController";
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -129,6 +130,7 @@ const types = [
     CVViewer,
     CVReader,
     CVOrbitNavigation,
+    CVDerivativesController,
     CVBackground,
     CVFloor,
     CVGrid,

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -148,7 +148,7 @@ export default class CVDerivativesController extends Component{
   }
 
   protected static readonly ins = {
-    enabled: types.Boolean("Settings.Enabled", true),
+    enabled: types.Boolean("LOD.Enabled", true),
   }
 
 

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -191,20 +191,21 @@ export default class CVDerivativesController extends Component{
     //  2. This is total available space and any object can have any number of textures (we'd be able to refine this exact number if we wanted)
     //      to which we need to add lightmaps, environment, etc. We just simplify to 1/4 the texture space
     let budget = Math.pow(this.renderer.outs.maxTextureSize.value/2, 2);
+    let reasons :string[] = [];
     if(typeof navigator.hardwareConcurrency === "number" && navigator.hardwareConcurrency < 4){
-      console.debug("Reduce budget because of low CPU count");
+      reasons.push("low CPU");
       budget = budget/2;
     }
     if(IS_MOBILE){
-      console.debug("Reduce budget because of mobile device");
+      reasons.push("mobile device");
       budget = budget/2;
     }
     if(typeof (navigator as any).deviceMemory === "number" && (navigator as any).deviceMemory < 8){
-      console.debug("Reduce budget because of low RAM");
+      reasons.push("low RAM");
       budget = Math.min(budget, sizes[EDerivativeQuality.High]*4);
     }
     this._budget = Math.max(MIN_BUDGET, budget);
-    console.debug("Performance budget: ", Math.sqrt(this._budget));
+    if(reasons.length) console.debug(`Lowered Performance budget: ${Math.sqrt(this._budget)} (${reasons.join(", ")})`);
   }
 
   tock(context :IPulseContext) :boolean{
@@ -498,7 +499,7 @@ export default class CVDerivativesController extends Component{
       }
     }
 
-    if(currently_loading != 0){
+    if(currently_loading != 0 && ENV_DEVELOPMENT){
       const countQ = (q :EDerivativeQuality)=>collection.reduce((s, m)=>(s+((m.model.ins.quality.value === q)?1:0)), 0);
       console.debug(`models quality: [%d, %d, %d, %d]. loading %d models with %d/%d downgrades %s`, 
         countQ(EDerivativeQuality.High),

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -213,7 +213,19 @@ export default class CVDerivativesController extends Component{
   tock(context :IPulseContext) :boolean{
     const cameraComponent = this._scene?.activeCameraComponent;
     if (!this.ins.enabled.value || !cameraComponent) {
-        return false;
+      let modifiedAModel = false;
+      this.getGraphComponents(CVModel2).map(model=>{
+        // Wait for thumb quality to load
+        if (!model.isLoading()){
+          // Load the highest quality derivative available
+          const highestQualityDerivative = model.derivatives.select(EDerivativeUsage.Web3D, 4);
+          if(highestQualityDerivative && highestQualityDerivative.data.quality != model.ins.quality.value){
+            model.ins.quality.setValue(highestQualityDerivative.data.quality);
+            modifiedAModel = true;
+          }
+        }
+      })
+      return modifiedAModel;
     }
 
     if(!context.tickUpdated && !context.tockUpdated && !this._should_update) return false;

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -225,7 +225,7 @@ export default class CVDerivativesController extends Component{
     }
     //We are updating now, so set this to false.
     this._should_update = false
-
+    this._last_updated = context.secondsElapsed;
 
     let currently_loading = 0;
 //    const weights :Array<[string, any]>= [];
@@ -426,6 +426,8 @@ export default class CVDerivativesController extends Component{
       collection.filter((item)=> (item.model.isLoading() && item.model.ins.quality.value != item.qualityRequest && item.model.activeDerivative)).forEach((item)=> {
           item.model.ins.quality.setValue(item.model.activeDerivative.data.quality);
           currently_loading --;
+          textureSize += getSize(item.model, item.qualityRequest) - getSize(item.model, item.model.ins.quality.value);
+          textureSizeBeforeUpgrades += getSize(item.model, item.qualityRequest) - getSize(item.model, item.model.ins.quality.value);
       })
     }
 
@@ -491,8 +493,8 @@ export default class CVDerivativesController extends Component{
       let toDowngrade = new Map<CVModel2, EDerivativeQuality>();
       // texture size if we take into the currently downgraded textures and upgrade the one of "item"
       let textureSizeWithDowngrade = textureSizeBeforeUpgrades + getSize(item, q) - getSize(item, item.ins.quality.value);
-      // Identifying models with lower weights (<1.5*weight of item) that could be downgraded. Lower weights are first.
-      const downgradables = collection.filter(i => (!(i.model.ins.quality.changed) && i.model.ins.quality.value >= q && i.weight*1.5< w && !downgrades.has(i.model)));
+      // Identifying models with lower weights (<1.25*weight of item) that could be downgraded. Lower weights are first.
+      const downgradables = collection.filter(i => (!(i.model.ins.quality.changed) && i.model.ins.quality.value >= q && i.weight*1.25< w && !downgrades.has(i.model)));
       // Check for a quality one level lower and calculate the amount of texture saved.
       // Stop once it is enough to fit the current "item" upgrade
       let i = 0;
@@ -505,18 +507,18 @@ export default class CVDerivativesController extends Component{
         i++;
       }
       // If enough textures can be downgraded, dowgrade them.
-      if (textureSizeWithDowngrade < this._budget && toDowngrade.size > 0 ){
+      if (textureSizeWithDowngrade < this._budget){
         for (const [itemToDowngrade, newQuality] of toDowngrade){
           //console.log("Downgrading ", itemToDowngrade.node.name, " to ", newQuality , " to upgrade ", item.node.name)
           downgrades.set(itemToDowngrade, newQuality);
           textureSize += getSize(itemToDowngrade, newQuality) - getSize(item, item.ins.quality.value);
-          textureSizeBeforeUpgrades += getSize(itemToDowngrade, newQuality) - getSize(item, item.ins.quality.value);
         }
+        textureSizeBeforeUpgrades = textureSizeWithDowngrade;
         // otherwise cancel the upgrade
       } else {
       //We are SURE `q != 0` because otherwise it wouldn't have been pushed to the upgrades queue
         upgrades.delete(item);
-        textureSize += getSize(item, q-1) - getSize(item, q);
+        textureSize += getSize(item, item.ins.quality.value ) - getSize(item, q);
       }
     }
     const priority_downgrades = downgrades.size - normal_downgrades - hard_downgrades;
@@ -551,7 +553,7 @@ export default class CVDerivativesController extends Component{
         (priority_downgrades != 0?`(${priority_downgrades} priority downgrades)`:"")
       );
     }
-    return 0 < downgrades.size;
+    return 0 < downgrades.size + upgrades.size;
   }
   
   fromData(data: ILOD)

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -213,19 +213,7 @@ export default class CVDerivativesController extends Component{
   tock(context :IPulseContext) :boolean{
     const cameraComponent = this._scene?.activeCameraComponent;
     if (!this.ins.enabled.value || !cameraComponent) {
-      let modifiedAModel = false;
-      this.getGraphComponents(CVModel2).map(model=>{
-        // Wait for thumb quality to load
-        if (!model.isLoading()){
-          // Load the highest quality derivative available
-          const highestQualityDerivative = model.derivatives.select(EDerivativeUsage.Web3D, 4);
-          if(highestQualityDerivative && highestQualityDerivative.data.quality != model.ins.quality.value){
-            model.ins.quality.setValue(highestQualityDerivative.data.quality);
-            modifiedAModel = true;
-          }
-        }
-      })
-      return modifiedAModel;
+      return false
     }
 
     if(!context.tickUpdated && !context.tockUpdated && !this._should_update) return false;

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -1,0 +1,331 @@
+
+import CObject3D, { Node, types } from "@ff/scene/components/CObject3D";
+import CScene from "@ff/scene/components/CScene";
+import CVModel2 from "./CVModel2";
+import CPulse, { IPulseContext, IPulseEvent } from "@ff/graph/components/CPulse";
+import Component from "@ff/graph/Component";
+import { EDerivativeQuality, EDerivativeUsage } from "client/schema/model";
+import CRenderer from "@ff/scene/components/CRenderer";
+import { Vector2, Vector3, Box3, Matrix4, Object3D } from "three";
+import CTransform from "@ff/scene/components/CTransform";
+import CVNode from "./CVNode";
+
+interface ILOD{
+  enabled?:boolean;
+}
+
+/**
+ * Expected map sizes in pixels
+ * The number given is number of pixels for a square map of the expected quality
+ */
+const sizes = {
+  [EDerivativeQuality.High]: 4096*4096,
+  [EDerivativeQuality.Medium]: 2048*2048,
+  [EDerivativeQuality.Low]: 1024*1024,
+  [EDerivativeQuality.Thumb]: 512*512,
+} as const
+
+
+function isOnScreen(b :Box3) :boolean{
+  return Math.min(Math.abs(b.max.x), Math.abs(b.min.x)) < 1 && Math.min(Math.abs(b.max.y), Math.abs(b.min.y)) < 1;
+}
+
+/**
+ * How far from center is the centermost part of the object?
+ * dxy = 0: Object crosses the image's center
+ * dxy = 1 object's nearest point would be just outside screen space if located on the X or Y axis
+ * dxy = 2: Object's nearest border is just beyond the screen's diagonal edge
+ * We add X offset and Y offset because we kind of _want_ diagonals to be a little underweighted
+ * 
+ */
+export function maxCenterWeight(b :Box3){
+    let dxy = Math.max(-b.max.x, b.min.x, 0) + Math.max(-b.max.y, b.min.y, 0);
+    return 1 / (Math.pow(1+dxy,4));
+}
+
+
+const hyst = 0.02; //In absolute % of screen area unit
+const steps = [
+    [0.04, EDerivativeQuality.Thumb],
+    [0.1, EDerivativeQuality.Low],
+    [0.4, EDerivativeQuality.Medium],
+];
+/**
+ * Calculate desired quality setting
+ * 
+ * An hysteresis is necessary to prevent flickering, 
+ * but it would be interesting to configure if we upgrade-first or downgrade-first
+ * depending on resources contention 
+ * 
+ * @fixme here we should take into account the renderer's resolution:
+ * we probably don't need a 4k texture when rendering an object over 40% of a 800px viewport
+ */
+export function getQuality(current :EDerivativeQuality, relSize:number):EDerivativeQuality{
+  return steps.find(([size, q])=>{
+      if (current <= q) size += hyst;
+      return relSize < size;
+  })?.[1] ?? EDerivativeQuality.High;
+}
+
+/**
+ * Due to the nature of NDC coordinates, size on the (x, y, 0) plane would be infinite
+ * Simply clamp it for now.
+ */
+function clampSize(size :number){
+  return Math.min(size, 2);
+}
+
+const _ndcBox = new Box3();
+const _localBox = new Box3();
+const _vec3a = new Vector3();
+const _mat4 = new Matrix4();
+const _cam_fwd = new Vector3(0, 0, 1);
+
+/**
+ * Dynamic LOD handling. * 
+ */
+export default class CVDerivativesController extends Component{
+
+  static readonly typeName: string = "CVDerivativesController";
+  static readonly isSystemSingleton: boolean = true;
+
+  static readonly text: string = "Derivatives selection";
+  static readonly icon: string = "";
+
+  /** Number of frames since last change */
+  private _debounce :number = 0;
+
+  private _budget = sizes[EDerivativeQuality.High]*2;
+
+  threshold(q :EDerivativeQuality){
+    return this._budget - sizes[q]*2;
+  }
+
+  protected static readonly ins = {
+    enabled: types.Boolean("Settings.Enabled", true),
+  }
+
+
+  ins = this.addInputs<CObject3D, typeof CVDerivativesController.ins>(CVDerivativesController.ins);
+
+
+  get settingProperties() {
+    return [
+        this.ins.enabled,
+    ];
+  }
+  private _scene :CScene;
+  protected get renderer() {
+    return this.getMainComponent(CRenderer);
+  }
+
+  get activeScene(){
+    return this.renderer?.activeSceneComponent;
+  }
+
+  constructor(node: Node, id: string)
+  {
+      super(node, id);
+      this._scene = this.activeScene;
+      this.renderer.outs.maxTextureSize.on("value", this.setTextureBudget);
+  }
+
+
+  setTextureBudget = ()=>{
+    // We expect scene performance to always be texture-limited.
+    // For example a hundred untextured objects with 25k vertices each would pose absolutely no problem even to a low end mobile device. 
+    // However a few 4k maps are enough to overload such a device's GPU and internet connection.
+    // First, evaluate raw maximum texture space as an upper bound. This is halved because:
+    //  1. we don't particularly want to max-out. This is not a "reasonable", but a "system max supported" value. 
+    //  2. This is total available space and any object can have any number of textures (we'd be able to refine this exact number if we wanted)
+    //      to which we need to add lightmaps, environment, etc. We just simplify to 1/4 the texture space
+    let budget = Math.pow(this.renderer.outs.maxTextureSize.value/2, 2);
+    if(typeof navigator.hardwareConcurrency === "number" && navigator.hardwareConcurrency < 4){
+      console.debug("Reduce budget because of low CPU count");
+      budget = budget/2;
+    }
+    if((navigator as any).userAgentData?.mobile){
+      console.debug("Reduce budget because of mobile device");
+      budget = budget/1.5; //
+    }
+    if(typeof (navigator as any).deviceMemory === "number" && (navigator as any).deviceMemory < 8){
+      console.debug("Reduce budget because of low RAM");
+      budget = Math.min(budget, sizes[EDerivativeQuality.High]*4);
+    }
+    this._budget = Math.max(sizes[EDerivativeQuality.High]*2, budget);
+    console.debug("Performance budget: ", Math.sqrt(this._budget));
+  }
+
+  tock(context :IPulseContext) :boolean{
+    const cameraComponent = this._scene?.activeCameraComponent;
+    if (!this.ins.enabled.value || !cameraComponent) {
+        return false;
+    }
+    if(this._debounce++ < 20){
+      return false;
+    }
+
+    cameraComponent.camera.getWorldDirection(_cam_fwd);
+
+    let changes = 0; //We don't want to start too many upgrades at once
+    const weights :Array<[string, any]>= [];
+    let models :Array<{model:CVModel2, size:number, clipped: boolean, quality:EDerivativeQuality, weight: number}> = this.getGraphComponents(CVModel2).map(model=>{
+      _ndcBox.makeEmpty();
+
+      //We can't just use the model's matrixWorld here because it might not have loaded yet.
+      //In this case the bounding box is whatever's defined in the scene file.
+      const scale = model.outs.unitScale.value;
+      let t :CTransform|CVNode = model.transform;
+      _localBox.copy(model.localBoundingBox);
+      _localBox.min.multiplyScalar(scale);
+      _localBox.max.multiplyScalar(scale);
+      while(t){
+        _mat4.fromArray(t.outs.matrix.value);
+        _localBox.applyMatrix4(_mat4);
+        t = t.parent as CTransform|CVNode;
+      }
+      let clipped = true;
+      //Ideally we use NDC (Normalized Display Coordinates) to compute the perceived size of an object on-screen
+      //The thing with NDC is they are crap at representing objects that are on the side of the camera
+      //They tends to have infinite (X,Y) sizes that don't make any sense
+      //Additionally it's hard to make sense of objects that crosses the camera's cross plane.
+      [
+        [_localBox.min.x, _localBox.min.y, _localBox.min.z],
+        [_localBox.max.x, _localBox.min.y, _localBox.min.z],
+        [_localBox.max.x, _localBox.max.y, _localBox.min.z],
+        [_localBox.max.x, _localBox.max.y, _localBox.max.z],
+        [_localBox.min.x, _localBox.max.y, _localBox.max.z],
+        [_localBox.min.x, _localBox.min.y, _localBox.max.z],
+        [_localBox.max.x, _localBox.min.y, _localBox.max.z],
+        [_localBox.min.x, _localBox.max.y, _localBox.min.z],
+      ].forEach((coords:[number, number, number], index)=>{
+          _vec3a.set(...coords).project(cameraComponent.camera);
+          if(cameraComponent.camera.near < _vec3a.z && _vec3a.z < 1){
+            if(Math.abs(_vec3a.x) < 1 && Math.abs(_vec3a.y) < 1){
+              clipped = false;
+            }
+            _ndcBox.expandByPoint(_vec3a);
+          }
+      });
+
+      _localBox.getCenter(_vec3a);
+      const distance = _vec3a.distanceTo(cameraComponent.camera.position)/cameraComponent.camera.far;
+      const angle = _vec3a.angleTo(_cam_fwd);
+
+      _localBox.getSize(_vec3a);
+      _ndcBox.min.clampScalar(-1,1);
+      _ndcBox.max.clampScalar(-1,1);
+      _ndcBox.getSize(_vec3a);
+      let visibleSize = (_vec3a.x *_vec3a.y)/4;
+      //let visibleSize = Math.abs((_localBox.max.angleTo(_cam_fwd) - _localBox.min.angleTo(_cam_fwd)))/(cameraComponent.camera.fov*Math.PI/180);
+
+
+      const depthMod = Math.max(1-distance, 0.1);
+      const angleMod = 1 - Math.abs(angle)/Math.PI;
+
+      weights.push([model.ins.name.value, {distance, angle, depthMod, angleMod, visibleSize}]);
+
+      const weight = depthMod*angleMod;
+
+      //Upgrade only here
+      let quality =  Math.max(model.ins.quality.value, getQuality(model.ins.quality.value, visibleSize));
+
+      return {model, size:visibleSize, clipped, weight, quality};
+    })
+    .sort((a, b)=> a.weight - b.weight); //Models that have a high difference between their size and weight are the first to get downgraded
+
+
+
+
+
+
+    /** @fixme : ideally, cancel anything that is in-glight and no longer needed */
+
+    //Now we have a list of upgrade-only quality requests.
+    //We need to know whether or not we'd want to downgrade some models
+    let textureSize = models.reduce((size, {quality})=>size + sizes[quality], 0);
+    let clippedOnly = true, idx = 0, downgrades = 0, hidden = 0, passes=1;
+
+    while(this._budget < textureSize){
+      const model = models[idx];
+      if(model.clipped || !clippedOnly){
+        let q = getQuality(model.model.ins.quality.value, model.size);
+        if( q < model.quality){
+          textureSize = textureSize - sizes[model.quality] + sizes[q];
+          model.quality = q;
+          if(!model.clipped) downgrades++;
+        }
+      }
+      if(models.length <= ++idx){
+        passes++;
+        for(let model of models){
+          //Here it is important to decide _how_ models size is to be changed
+          //It affects which models will be downgraded first
+          model.size = model.size*model.weight;
+        }
+        if(passes == 1)console.debug("%d downgrades after first pass", downgrades);
+        if(model.quality == EDerivativeQuality.Thumb) break; // Prevent infinite loop
+        clippedOnly = false;
+        idx = 0;
+      }
+    }
+
+    let loading = models.reduce((s,m)=>s+(m.model.isLoading()?1:0),0);
+    for(let i = 0; i < models.length; i++){
+      if(5 < loading) break;
+      const  {model, quality} = models[i];
+      const current = model.ins.quality.value;
+
+      if(quality === current) continue;
+      const bestMatchDerivative = model.derivatives.select(EDerivativeUsage.Web3D, quality);
+      if(bestMatchDerivative && bestMatchDerivative.data.quality != current ){
+        if(current < bestMatchDerivative.data.quality && 2 < (++changes)){continue;}
+        /** @fixme should prevent having too many loading models at once because that creates network contention */
+        //console.debug("Set quality for ", model.ins.name.value, " from ", current, " to ", bestMatchDerivative.data.quality);
+        model.ins.quality.setValue(bestMatchDerivative.data.quality);
+      }
+    }
+
+
+    if(0 < changes){
+      this._debounce = 0;
+      let notClipped = models.filter(m=>!m.clipped);
+      let byDistance = weights.sort(([, a],[, b])=> a.distance - b.distance).slice(0);
+      let byAngle = weights.sort(([, a],[, b])=> a.angle - b.angle).reverse().slice(0, 4);
+      let byVsize = weights.sort(([, a],[, b])=> a.visibleSize - b.visibleSize).reverse().slice(0, 4);
+
+      // console.debug("Centered : ", byAngle.map(m=>`${m[0]} (${m[1].angleMod})`).join(", "));
+      // console.debug("Visible : \n\t", notClipped.map(m=>m.model.ins.name.value).join("\n\t"))
+      //console.log("VSize : ", byVsize[0][1].visibleSize, byVsize.map(m=>m[0]).join(", "));
+  
+
+      const countQ = (q :EDerivativeQuality)=>models.reduce((s, m)=>(s+((m.quality=== q)?1:0)), 0);
+      console.debug(`models :(%d, %d, %d, %d)`, countQ(EDerivativeQuality.High), countQ(EDerivativeQuality.Medium), countQ(EDerivativeQuality.Low), countQ(EDerivativeQuality.Thumb));
+      //console.debug(`%d/%d clipped models, %d hidden, %d downgraded in %d downgrade passes`, models.reduce((s,m)=>s+(m.clipped?1:0), 0), models.length, hidden, downgrades, passes);
+      //console.debug("High quality models : ", models.filter((m)=>m.quality ===EDerivativeQuality.High).map(m=>m.model.ins.name.value).join(", "))
+    }
+    // We could refine our "pixel budget" here by getting the actual number of maps loaded on each model
+    return 0 < changes;
+  }
+  
+  fromData(data: ILOD)
+    {
+        data = data || {} as ILOD;
+
+        this.ins.copyValues({
+            enabled: !!data.enabled,
+        });
+    }
+
+    toData(): ILOD
+    {
+        const ins = this.ins;
+        const data: Partial<ILOD> = {};
+
+        data.enabled = ins.enabled.value;
+        
+        return data as ILOD;
+    }
+
+
+}

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -424,7 +424,6 @@ export default class CVDerivativesController extends Component{
     // We cancel downsizing only if target textures are not over the allowed budget
     if (textureSize < this._budget){
       collection.filter((item)=> (item.model.isLoading() && item.model.ins.quality.value != item.qualityRequest && item.model.activeDerivative)).forEach((item)=> {
-        console.log("Cancelling loading model for :" , item.model.node.name, "in quality ", item.model.ins.quality.value, "to keep ", item.qualityRequest)
           item.model.ins.quality.setValue(item.model.activeDerivative.data.quality);
           currently_loading --;
       })

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -89,7 +89,6 @@ const _vec3b = new Vector3();
 const _vecSphericalb = new Spherical();
 const _quat = new Quaternion();
 const _mat4 = new Matrix4();
-const _cam_fwd = new Vector3(0, 0, 1);
 const quaternion90AroundZ = new Quaternion().setFromEuler(new Euler(0,0,Math.PI/2));
 const quaternionMinus90AroundZ = quaternion90AroundZ.clone().conjugate();
 
@@ -227,7 +226,6 @@ export default class CVDerivativesController extends Component{
     //We are updating now, so set this to false.
     this._should_update = false
 
-    cameraComponent.camera.getWorldDirection(_cam_fwd);
 
     let currently_loading = 0;
 //    const weights :Array<[string, any]>= [];

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -10,6 +10,7 @@ import { Vector2, Vector3, Box3, Matrix4, Quaternion, Spherical, Plane, Euler } 
 import CTransform from "@ff/scene/components/CTransform";
 import CVNode from "./CVNode";
 import * as helpers from "@ff/three/helpers";
+import { IS_MOBILE } from "client/constants";
 
 interface ILOD{
   enabled?:boolean;
@@ -194,9 +195,9 @@ export default class CVDerivativesController extends Component{
       console.debug("Reduce budget because of low CPU count");
       budget = budget/2;
     }
-    if((navigator as any).userAgentData?.mobile){
+    if(IS_MOBILE){
       console.debug("Reduce budget because of mobile device");
-      budget = budget/1.5; //
+      budget = budget/2;
     }
     if(typeof (navigator as any).deviceMemory === "number" && (navigator as any).deviceMemory < 8){
       console.debug("Reduce budget because of low RAM");

--- a/source/client/components/CVDerivativesController.ts
+++ b/source/client/components/CVDerivativesController.ts
@@ -84,6 +84,7 @@ const _vec3b = new Vector3();
 const _quat = new Quaternion();
 const _mat4 = new Matrix4();
 const _cam_fwd = new Vector3(0, 0, 1);
+const _ndc_fwd = new Vector3(0, 0, 1);
 
 /**
  * Dynamic LOD handling. * 
@@ -219,9 +220,18 @@ export default class CVDerivativesController extends Component{
           }
       });
 
-      _localBox.getCenter(_vec3a);
-      const distance = _vec3a.distanceTo(cameraComponent.camera.position)/cameraComponent.camera.far;
-      const angle = _vec3a.angleTo(_cam_fwd);
+      cameraComponent.camera.getWorldPosition(_vec3a);
+      //Best-case distance
+      let distance =  _localBox.distanceToPoint(_vec3a)/cameraComponent.camera.far;
+      let angle = 0;
+      if(distance != 0){
+        _vec3a.set(
+          (_ndcBox.min.x < 0 && 0 < _ndcBox.max.x)? 0: Math.min(Math.abs(_ndcBox.max.x), Math.abs(_ndcBox.min.x)),
+          (_ndcBox.min.y < 0 && 0 < _ndcBox.max.y)?0: Math.min(Math.abs(_ndcBox.max.y), Math.abs(_ndcBox.min.y)),
+          _ndcBox.max.z,
+        );
+        angle = _vec3a.angleTo(_ndc_fwd);
+      }
 
       //_localBox.getSize(_vec3a);
       _ndcBox.min.clampScalar(-1,1);

--- a/source/client/components/CVDerivativesTask.ts
+++ b/source/client/components/CVDerivativesTask.ts
@@ -47,10 +47,19 @@ export default class CVDerivativesTask extends CVTask
         configuration.bracketsVisible = false;
         configuration.gridVisible = false;
         configuration.annotationsVisible = false;
+        configuration.lodEnabled = false;
     }
 
     createView()
     {
         return new DerivativesTaskView(this);
+    }
+    activateTask(): void {
+        this.startObserving();
+        super.activateTask()
+    }
+    deactivateTask(): void {
+        this.stopObserving();
+        super.deactivateTask();
     }
 }

--- a/source/client/components/CVModel2.ts
+++ b/source/client/components/CVModel2.ts
@@ -296,7 +296,13 @@ export default class CVModel2 extends CObject3D
         }
 
         if (!this.activeDerivative && ins.autoLoad.changed && ins.autoLoad.value) {
-            this.autoLoad();
+            this.autoLoad().then(()=> {
+                let setup = this.getGraphComponent(CVSetup);
+                 if (!setup.derivatives.ins.enabled.value){
+                    const derivative = this.derivatives.select(EDerivativeUsage.Web3D, EDerivativeQuality.Highest);
+                    this.ins.quality.setValue(derivative.data.quality);
+                 }
+            });
         }
         else if (ins.quality.changed) {
             const derivative = this.derivatives.select(EDerivativeUsage.Web3D, ins.quality.value);

--- a/source/client/components/CVModel2.ts
+++ b/source/client/components/CVModel2.ts
@@ -808,10 +808,9 @@ export default class CVModel2 extends CObject3D
                     this._boxFrame = null;
                 }
 
-                // // update bounding box based on loaded derivative
-                // @fixme add back once sure it's not causing dynamic LOD flickering
-                // this._localBoundingBox.makeEmpty();
-                // helpers.computeLocalBoundingBox(derivative.model, this._localBoundingBox);
+                // update bounding box based on loaded derivative
+                this._localBoundingBox.makeEmpty();
+                helpers.computeLocalBoundingBox(derivative.model, this._localBoundingBox);
                 this.outs.updated.set();
 
                 if (ENV_DEVELOPMENT) {

--- a/source/client/components/CVSetup.ts
+++ b/source/client/components/CVSetup.ts
@@ -35,6 +35,7 @@ import CVSnapshots from "./CVSnapshots";
 import CVEnvironment from "./CVEnvironment";
 import CVLanguageManager from "./CVLanguageManager";
 import CVAudioManager from "./CVAudioManager";
+import CVDerivativesController from "./CVDerivativesController";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -60,6 +61,7 @@ export default class CVSetup extends Component
         "reader": CVReader,
         "viewer": CVViewer,
         "navigation": CVOrbitNavigation,
+        "derivatives": CVDerivativesController, 
         "background": CVBackground,
         "environment": CVEnvironment,
         "language": CVLanguageManager,
@@ -82,6 +84,7 @@ export default class CVSetup extends Component
     reader: CVReader;
     viewer: CVViewer;
     navigation: CVOrbitNavigation;
+    derivatives: CVDerivativesController;
     background: CVBackground;
     floor: CVFloor;
     grid: CVGrid;

--- a/source/client/components/CVSlicer.ts
+++ b/source/client/components/CVSlicer.ts
@@ -17,14 +17,14 @@
 
 import { Box3, Mesh } from "three";
 
-import Component, { types } from "@ff/graph/Component";
+import Component, { IComponentEvent, types } from "@ff/graph/Component";
 
 import { ISlicer, ESliceAxis, TSliceAxis } from "client/schema/setup";
 
 import UberPBRMaterial from "../shaders/UberPBRMaterial";
 
 import CVScene from "./CVScene";
-import CVModel2 from "./CVModel2";
+import CVModel2, { IModelLoadEvent } from "./CVModel2";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -86,6 +86,12 @@ export default class CVSlicer extends Component
 
         const scene = this.getGraphComponent(CVScene);
         this.ins.boundingBox.linkFrom(scene.outs.boundingBox);
+        this.graph.components.on(CVModel2, this.onModelComponent, this);
+    }
+
+    dispose(){
+        super.dispose();
+        this.graph.components.off(CVModel2, this.onModelComponent, this);
     }
 
     update(context)
@@ -183,4 +189,21 @@ export default class CVSlicer extends Component
         material.cutPlaneDirection.fromArray(this.plane);
         material.cutPlaneColor.fromArray(ins.color.value);
     }
+
+    protected onModelLoad(){
+        this.ins.enabled.set();
+    }
+
+    protected onModelComponent(event: IComponentEvent<CVModel2>)
+    {
+        const component = event.object;
+
+        if (event.add) {
+            component.on<IModelLoadEvent>("model-load", this.onModelLoad, this);
+        }
+        else if (event.remove) {
+            component.off<IModelLoadEvent>("model-load", this.onModelLoad, this);
+        }
+    }
+
 }

--- a/source/client/components/CVTask.ts
+++ b/source/client/components/CVTask.ts
@@ -64,6 +64,7 @@ export default class CVTask extends CVNodeObserver
         interfaceVisible: undefined,
         gridVisible: undefined,
         annotationsVisible: undefined,
+        lodEnabled: undefined,
     };
 
     private _savedConfig = {
@@ -71,6 +72,7 @@ export default class CVTask extends CVNodeObserver
         interfaceVisible: undefined,
         gridVisible: undefined,
         annotationsVisible: undefined,
+        lodEnabled: undefined,
     };
 
     dispose()
@@ -140,6 +142,9 @@ export default class CVTask extends CVNodeObserver
             if (savedConfig.interfaceVisible !== undefined) {
                 previous.setup.interface.ins.visible.setValue(savedConfig.interfaceVisible);
             }
+            if(savedConfig.lodEnabled !== undefined) {
+                previous.setup.derivatives.ins.enabled.setValue(savedConfig.lodEnabled);
+            }
         }
         if (next) {
             if (configuration.gridVisible !== undefined) {
@@ -156,6 +161,11 @@ export default class CVTask extends CVNodeObserver
                 const prop = next.setup.interface.ins.visible;
                 savedConfig.interfaceVisible = prop.value;
                 prop.setValue(!!configuration.interfaceVisible);
+            }
+            if(configuration.lodEnabled !== undefined) {
+                const prop = next.setup.derivatives.ins.enabled;
+                savedConfig.lodEnabled = prop.value;
+                prop.setValue(!!configuration.lodEnabled);
             }
         }
     }

--- a/source/client/io/GeometryReader.ts
+++ b/source/client/io/GeometryReader.ts
@@ -17,8 +17,8 @@
 
 import { LoadingManager, BufferGeometry } from "three";
 
-import {OBJLoader} from "three/examples/jsm/loaders/OBJLoader";
-import {PLYLoader} from "three/examples/jsm/loaders/PLYLoader";
+import {OBJLoader} from "three/examples/jsm/loaders/OBJLoader.js";
+import {PLYLoader} from "three/examples/jsm/loaders/PLYLoader.js";
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/source/client/models/Derivative.ts
+++ b/source/client/models/Derivative.ts
@@ -78,8 +78,8 @@ export default class Derivative extends Document<IDerivative, IDerivativeJSON>
         }
 
         if(this.abortControl){
-            console.warn("Aborting inflight derivative load");
-            this.abortControl.abort("Derivative load cancelled"); //This should not happen, but if in doubt, cancel duplicates
+            ENV_DEVELOPMENT && console.warn("Aborting inflight derivative load");
+            this.abortControl.abort(new Error("Derivative load cancelled")); //This should not happen, but if in doubt, cancel duplicates
         }
         this.abortControl = new AbortController();
         const modelAsset = this.findAsset(EAssetType.Model);

--- a/source/client/models/DerivativeList.ts
+++ b/source/client/models/DerivativeList.ts
@@ -68,7 +68,6 @@ export default class DerivativeList
         for (let i = qualityIndex + 1; i < _qualityLevels.length; ++i) {
             const derivative = this.get(usage, _qualityLevels[i]);
             if (derivative) {
-                console.warn(`derivative quality '${qualityKey}' not available, using higher quality`);
                 return derivative;
             }
         }
@@ -76,7 +75,6 @@ export default class DerivativeList
         for (let i = qualityIndex - 1; i >= 0; --i) {
             const derivative = this.get(usage, _qualityLevels[i]);
             if (derivative) {
-                console.warn(`derivative quality '${qualityKey}' not available, using lower quality`);
                 return derivative;
             }
         }

--- a/source/client/ui/explorer/ContentView.ts
+++ b/source/client/ui/explorer/ContentView.ts
@@ -201,7 +201,7 @@ export default class ContentView extends DocumentView
         }
 
         return html`<div class="ff-fullsize sv-content-only">${sceneView}</div>
-            <sv-spinner ?visible=${isLoading} .assetPath=${this.assetPath}></sv-spinner>
+            <sv-spinner ?visible=${isLoading && isInitialLoad} .assetPath=${this.assetPath}></sv-spinner>
             ${captionView}
             ${promptVisible ? html`<sv-action-prompt></sv-action-prompt>` : null}`;
     }

--- a/source/client/webpack.config.js
+++ b/source/client/webpack.config.js
@@ -167,7 +167,7 @@ module.exports = function(env, argv)
         plugins: [
             new webpack.DefinePlugin({
                 ENV_PRODUCTION: JSON.stringify(!isDevMode),
-                ENV_DEVELOPMENT: JSON.stringify(isDevMode),
+                ENV_DEVELOPMENT: false,
                 ENV_OFFLINE: JSON.stringify(isOffline),
                 ENV_VERSION: JSON.stringify(`Voyager ${version} ${isDevMode ? " DEV" : " PROD"}`),
             }),

--- a/source/client/webpack.config.js
+++ b/source/client/webpack.config.js
@@ -167,7 +167,7 @@ module.exports = function(env, argv)
         plugins: [
             new webpack.DefinePlugin({
                 ENV_PRODUCTION: JSON.stringify(!isDevMode),
-                ENV_DEVELOPMENT: false,
+                ENV_DEVELOPMENT: JSON.stringify(isDevMode),
                 ENV_OFFLINE: JSON.stringify(isOffline),
                 ENV_VERSION: JSON.stringify(`Voyager ${version} ${isDevMode ? " DEV" : " PROD"}`),
             }),

--- a/source/test/components/CVDerivativesController.test.ts
+++ b/source/test/components/CVDerivativesController.test.ts
@@ -1,0 +1,31 @@
+import { expect } from "chai";
+
+import { EDerivativeQuality } from "client/schema/model";
+import {getQuality, maxCenterWeight} from "client/components/CVDerivativesController";
+import { Box3, Vector3 } from "three";
+
+
+describe("getQuality", function(){
+
+  it("Selects a quality level", function(){
+    expect(getQuality(EDerivativeQuality.Thumb, 1)).to.equal(EDerivativeQuality.High);
+    expect(getQuality(EDerivativeQuality.Thumb, 0)).to.equal(EDerivativeQuality.Thumb);
+  });
+  it("uses an hysteresis (downgrade first)", function(){
+    expect(getQuality(EDerivativeQuality.Thumb, 0.11)).to.equal(EDerivativeQuality.Low);
+    expect(getQuality(EDerivativeQuality.Medium, 0.11)).to.equal(EDerivativeQuality.Medium);
+    expect(getQuality(EDerivativeQuality.Thumb, 0.13)).to.equal(EDerivativeQuality.Medium);
+  });
+});
+
+
+describe("maxCenterWeight", function(){
+  it("returns 1 for a box that crosses the center", function(){
+    let b = new Box3(new Vector3(-1,-1,-1), new Vector3(1, 1, 1));
+    expect(maxCenterWeight(b)).to.equal(1);
+  });
+  it("returns 1/2 for just-out-of-screen objects", function(){
+    let b = new Box3(new Vector3(1,0,0), new Vector3(2, 1, 0));
+    expect(maxCenterWeight(b)).to.equal(0.5);
+  });
+})

--- a/source/test/tsconfig.json
+++ b/source/test/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+      "target": "ES2017",
+      "module": "CommonJS",
+      "sourceMap": true,
+      //"strict": true,
+      "esModuleInterop": true,
+      "resolveJsonModule": true,
+      "moduleResolution": "node",
+      //"noUnusedLocals": true,
+      "experimentalDecorators": true,
+      "skipLibCheck": true,
+      "noEmitOnError": false,
+      "baseUrl": ".",
+      "outDir": "build",
+      "paths": {
+          "client/*": [ "../client/*" ],
+          "@ff/core/*": [ "../../libs/ff-core/source/*" ],
+          "@ff/graph/*": [ "../../libs/ff-graph/source/*" ],
+          "@ff/browser/*": [ "../../libs/ff-browser/source/*" ],
+          "@ff/ui/*": [ "../../libs/ff-ui/source/*" ],
+          "@ff/three/*": [ "../../libs/ff-three/source/*" ],
+          "@ff/scene/*": [ "../../libs/ff-scene/source/*" ]
+      }
+  },
+  "include": ["./**/*.test.ts", "../client/global.d.ts"]
+}

--- a/source/test/webpack.config.js
+++ b/source/test/webpack.config.js
@@ -1,0 +1,94 @@
+"use strict";
+
+const path = require("path");
+const { readdirSync } = require('fs');
+
+const project = path.resolve(__dirname, "../..");
+
+const dirs = {
+    project,
+    source: path.resolve(project, "source"),
+    assets: path.resolve(project, "assets"),
+    output: path.resolve(__dirname, "build"),
+    modules: path.resolve(project, "node_modules"),
+    libs: path.resolve(project, "libs"),
+};
+
+
+const list = (dir)=>{
+  return readdirSync(dir, {withFileTypes:true}).map(f=>{
+    if(f.isDirectory()) return list(path.join(dir,f.name));
+    else return path.join(dir,f.name);
+  }).flat().filter(f=>/\.test\.ts$/i.test(f))
+}
+
+const files = list(__dirname).map(p=>path.relative(__dirname, p)).reduce((entries, entry)=>({...entries, [entry.split("/").pop().replace(".test.ts", "")]: "./"+entry}), {});
+
+module.exports = {
+    mode: "development",
+    devtool: "source-map",
+    entry: files,
+    context: __dirname,
+    output: {
+        path: dirs.output,
+        filename: "test/[name].test.js",
+        clean: true,
+    },
+
+    resolve: {
+        modules: [
+            dirs.modules
+        ],
+        // Aliases for FF Foundation Library components
+        alias: {
+            "client": path.resolve(dirs.source, "client"),
+            "@ff/core": path.resolve(dirs.libs, "ff-core/source"),
+            "@ff/graph": path.resolve(dirs.libs, "ff-graph/source"),
+            "@ff/ui": path.resolve(dirs.libs, "ff-ui/source"),
+            "@ff/browser": path.resolve(dirs.libs, "ff-browser/source"),
+            "@ff/three": path.resolve(dirs.libs, "ff-three/source"),
+            "@ff/scene": path.resolve(dirs.libs, "ff-scene/source"),
+        },
+        // Resolvable extensions
+        extensions: [".ts", ".tsx", ".js", ".json"],
+        // Fallbacks
+        fallback: { },
+    },
+
+    // loaders execute transforms on a per-file basis
+    module: {
+        rules: [
+            {
+                // Raw text and shader files
+                test: /\.(txt|glsl|hlsl|frag|vert|fs|vs)$/,
+                loader: "raw-loader"
+            },
+            {
+                // Enforce source maps for all javascript files
+                enforce: "pre",
+                test: /\.js$/,
+                loader: "source-map-loader"
+            },
+            {
+                // Transpile SCSS to CSS and concatenate (to string)
+                test: /\.s?css$/,
+                use: ["null-loader"],
+                issuer: {
+                    //include: /source\/client\/ui\/explorer/     // currently only inlining explorer css
+                    and: [/source\/client\/ui\/explorer/]     // currently only inlining explorer css
+                }
+            },
+            {
+                // Typescript/JSX files
+                test: /\.tsx?$/,
+                use: "ts-loader",
+                exclude: /node_modules/,
+            },
+            {
+                test: /\.hbs$/,
+                loader: "handlebars-loader"
+            },
+        ]
+    },
+};
+


### PR DESCRIPTION
So there is this idea_ I worked on for the past few months that makes it possible to open a ~200 models scene with each model having a 4k diffuse (in `High` quality) on a mobile device. 

It's still a very rough prototype but I wanted to share it and begin discussions on what requirements we'd have to meet for this to get merged into voyager.

This branch temporarily includes https://github.com/Smithsonian/dpo-voyager/pull/266 to allow more camera mobility  and a lot of performance patches that should be (or have been) extracted to their own PRs. It also needs  to be rebased on Voyager's latest release. I'll do all this down the line as I clean everything up.

A working example is visible there: 

https://lodtest.ecorpus.holusion.net/ui/scenes/Lascaux_retake2/view

Same model, without LOD (everything is squashed together and downscaled to a 8k diffuse map) is publicly available [on the french ministry of culture website](https://archeologie.culture.gouv.fr/fr/media_externe?src=aHR0cHM6Ly90aGliYXVsdGd1aWxsYXVtb250LmdpdGh1Yi5pby9sYXNjYXV4M2QvMjAyNC0wNS0xNC1sYXNjYXV4M0RfRlIuaHRtbA==&token=fc131ee67240b9f8108015a4b4ec7c843a52fd36) and takes longer to load initially, has a lot of blur and doesn't even work on most mobile devices.

I also have a simpler demo example that should clearly show what is happening: 

https://lodtest.ecorpus.holusion.net/ui/scenes/simple_room/view

## Reasoning

I started with 2 facts :
 - as stated in https://github.com/Smithsonian/dpo-voyager/issues/254 even lower-end devices are fully capable of showing High quality  (4k textures) derivatives and there is no real point in trying to serve larger models even for high-end devices
 - Quality is selected at the scene level. Voyager has the ability to use heterogeneous quality internally but no way to exploit this.

My objective was to be able to handle spatially large models. Things like a large painting, multi-figure sculpture or a whole room. In such an environment, I want what's right under my nose to have a very high texture resolution (abt. 4k for something filling the whole screen is a good upper bound) but on the other hand I don't care about the resolution of pretty much everything else.

Having a scene with 10s  of objects, each with 4k diffuses tends to overload even desktop computers with low end discrete GPUs. I want to be able to have 100s of them. 

## How it works

I repurposed the existing `Derivative` system to dynamically switch models quality depending on the "perceived importance".

Pretty much everything happens in the new [CVDerivativeController](https://github.com/Smithsonian/dpo-voyager/blob/bbc8efb6d7c1a0fa095e3a10c92e8e8dda0df284/source/client/components/CVDerivativesController.ts) class. The scene is initially loaded with `Thumb`quality (as it was before). Then the controller regularly sorts every model in the scene by importance (on-screen size and angle to camera are taken into account) and increments the quality of the most important model(s). If/When too much models are upgraded, it downgrades models as needed starting with the least important ones.

## Heuristics

_Tradeofs that had to be made. Can and should be adjusted._

### Performance

Estimating a performance budget is hard (see  https://github.com/Smithsonian/dpo-voyager/issues/254). Even if we could reliably determine a device's graphic power (we can't), we can't know if the user wants us to use 100% of his computer's power.

I settled somewhat arbitrarily on an initial budget of 2 `High` resolution models that is then further decreased if we detect a low-end device (CPU count, RAM size, is a mobile device).

### Model weight

Models are weighted based on their **size** in camera space, their **distance** to the camera and their **angle** relative to the  `Camera.forward`.

The Distance modifier is somewhat redundant with size but we kinda want far away models to be less important even if they are very big. In fact most LOD algorithms are purely distance-based.

