### PR TITLE
use renderer's compileAsync to speed up models injection

### DIFF
--- a/source/client/io/ModelReader.ts
+++ b/source/client/io/ModelReader.ts
@@ -119,7 +119,7 @@ export default class ModelReader
         });
     }
 
-    protected createModelGroup(gltf): Object3D
+    protected async createModelGroup(gltf): Promise<Object3D>
     {
         const scene: Scene = gltf.scene;
 
@@ -161,6 +161,7 @@ export default class ModelReader
             }
         });
 
+        await this.renderer.views[0].renderer.compileAsync(scene, this.renderer.activeCamera, this.renderer.activeScene);
         return scene;
     }
 }


### PR DESCRIPTION
Time-to-full-load stays the same, but no loss either. In my tests it resulted in a consistent ~30% decrease of the "delayed animation frame" time when the model is first shown.
