### PR TITLE
fix language initialization from scene.setup

### DIFF
--- a/source/client/applications/ExplorerApplication.ts
+++ b/source/client/applications/ExplorerApplication.ts
@@ -377,6 +377,9 @@ Version: ${ENV_VERSION}
         if(props.reader) {
             this.enableReader(props.reader);
         }
+        if(props.lang) {
+            this.setLanguage(props.lang);
+        }
     }
 
     ////////////////////////////////////////////

--- a/source/client/components/CVLanguageManager.ts
+++ b/source/client/components/CVLanguageManager.ts
@@ -124,10 +124,7 @@ export default class CVLanguageManager extends Component
 
         const language = ELanguageType[data.language || "EN"] ?? ELanguageType[DEFAULT_LANGUAGE];
 
-        //If language has already been set, don't overwrite it.
-        if(ins.language.value < 0) {
-            ins.language.setValue(language);
-        }
+        ins.language.setValue(language);
     }
 
     toData(): ILanguage


### PR DESCRIPTION
remove bad check for language value. Find another way to force language from queryString

wasn't working properly since https://github.com/Smithsonian/dpo-voyager/pull/280 because of a dumb mistake of mine.

Forcing the language from `props` in `postLoadHandler` should work everytime, while allowing the value from `scene.setup.language` to be used when applicable.