### PR TITLE
Model load refactor

### DIFF
--- a/source/client/components/CVAssetManager.ts
+++ b/source/client/components/CVAssetManager.ts
@@ -205,7 +205,7 @@ class AssetLoadingManager extends LoadingManager
     protected onLoadingError()
     {
         if (ENV_DEVELOPMENT) {
-            console.error(`Loading error`);
+            console.log(`Loading error`);
         }
 
         // trigger update

--- a/source/client/components/CVAssetReader.ts
+++ b/source/client/components/CVAssetReader.ts
@@ -104,10 +104,10 @@ export default class CVAssetReader extends Component
         return this.fileLoader.getText(url);
     }
 
-    async getModel(assetPath: string): Promise<Object3D>
+    async getModel(assetPath: string, {signal}:{signal?:AbortSignal}={}): Promise<Object3D>
     {
         const url = this.assetManager.getAssetUrl(assetPath);
-        return this.modelLoader.get(url);
+        return this.modelLoader.get(url, {signal});
     }
 
     async getGeometry(assetPath: string): Promise<BufferGeometry>

--- a/source/client/components/CVModel2.ts
+++ b/source/client/components/CVModel2.ts
@@ -149,6 +149,12 @@ export default class CVModel2 extends CObject3D
     private _derivatives = new DerivativeList();
     private _activeDerivative: Derivative = null;
 
+    /**
+     * Separate from activeDerivative because when switching quality levels,
+     * we want to keep the active model until the new one is ready
+     */
+    private _loadingDerivative :Derivative = null;
+
     private _visible: boolean = true;
     private _boxFrame: Mesh = null;
     private _localBoundingBox = new Box3();
@@ -306,7 +312,7 @@ export default class CVModel2 extends CObject3D
         }
         else if (ins.quality.changed) {
             const derivative = this.derivatives.select(EDerivativeUsage.Web3D, ins.quality.value);
-            if (derivative && derivative !== this.activeDerivative) {
+            if (derivative) {
                 this.loadDerivative(derivative)
                 .catch(error => {
                     console.warn("Model.update - failed to load derivative");
@@ -749,7 +755,7 @@ export default class CVModel2 extends CObject3D
 
         // load sequence of derivatives one by one
         return sequence.reduce((promise, derivative) => {
-            return promise.then(() => { this.loadDerivative(derivative)}); 
+            return promise.then(() => this.loadDerivative(derivative)); 
         }, Promise.resolve());
     }
 
@@ -757,18 +763,40 @@ export default class CVModel2 extends CObject3D
      * Loads and displays the given derivative.
      * @param derivative
      */
-    protected loadDerivative(derivative: Derivative): Promise<void>
+    protected async loadDerivative(derivative: Derivative): Promise<void>
     {
         if(!this.node || !this.assetReader) {    // TODO: Better way to handle active loads when node has been disposed?
             console.warn("Model load interrupted.");
             return;
         }
+        if(this._loadingDerivative && this._loadingDerivative != derivative) {
+            this._loadingDerivative.unload();
+            this._loadingDerivative = null;
+        }
+        if (this._activeDerivative == derivative){
+            return;
+        }
+        if(this._loadingDerivative == derivative) {
+            return new Promise(resolve=> this._loadingDerivative.on("load", resolve));
+        }
+        
+        this._loadingDerivative = derivative;
 
         return derivative.load(this.assetReader)
             .then(() => {
-                if (!derivative.model || !this.node || 
-                  (this._activeDerivative && derivative.data.quality != this.ins.quality.value)) {
+                if ( !derivative.model
+                  || !this.node
+                  || (this._activeDerivative && derivative.data.quality != this.ins.quality.value)
+                ) {
+                    //Either derivative is not valid, or we have been disconnected, 
+                    // or this derivative is no longer needed as it's not the requested quality 
+                    // AND we already have _something_ to display
                     derivative.unload();
+                    return;
+                }
+
+                if(this._activeDerivative && this._activeDerivative == derivative){
+                    //a race condition can happen where a derivative fires it's callback but it's already the active one.
                     return;
                 }
 
@@ -778,11 +806,11 @@ export default class CVModel2 extends CObject3D
                 }
 
                 if (this._activeDerivative) {
-                    this.removeObject3D(this._activeDerivative.model);
+                    if(this._activeDerivative.model) this.removeObject3D(this._activeDerivative.model);
                     this._activeDerivative.unload();
                 }
-
                 this._activeDerivative = derivative;
+                this._loadingDerivative = null;
                 this.addObject3D(derivative.model);
                 this.renderer.activeSceneComponent.scene.updateMatrixWorld(true);
 
@@ -855,8 +883,11 @@ export default class CVModel2 extends CObject3D
 
                 this.emit<IModelLoadEvent>({ type: "model-load", quality: derivative.data.quality });
                 //this.getGraphComponent(CVSetup).navigation.ins.zoomExtents.set(); 
-            })
-            .catch(error => Notification.show(`Failed to load model derivative: ${error.message}`));
+            }).catch(error =>{
+                if(error.name == "AbortError" || error.name == "ABORT_ERR") return;
+                console.error(error);
+                Notification.show(`Failed to load model derivative: ${error.message}`)
+            });
     }
 
     protected addObject3D(object: Object3D)

--- a/source/client/io/ModelReader.ts
+++ b/source/client/io/ModelReader.ts
@@ -68,10 +68,10 @@ export default class ModelReader
         const dracoLoader = new DRACOLoader();
         dracoLoader.setDecoderPath(DEFAULT_SYSTEM_ASSET_PATH + "/js/draco/");
         this.renderer = renderer;
-        this.gltfLoader = new GLTFLoader(loadingManager);
+        this.gltfLoader = new GLTFLoader();
         this.gltfLoader.setDRACOLoader(dracoLoader);
         this.gltfLoader.setMeshoptDecoder(MeshoptDecoder);
-        const ktx2Loader = new KTX2Loader(this.loadingManager);
+        const ktx2Loader = new KTX2Loader();
         ktx2Loader.setTranscoderPath(DEFAULT_SYSTEM_ASSET_PATH + "/js/basis/");
         this.gltfLoader.setKTX2Loader(ktx2Loader);
         setTimeout(()=>{
@@ -102,7 +102,8 @@ export default class ModelReader
 
     get(url: string): Promise<Object3D>
     {
-        return new Promise((resolve, reject) => {
+        this.loadingManager.itemStart(url);
+        return new Promise<Object3D>((resolve, reject) => {
             this.gltfLoader.load(url, gltf => {
                 resolve(this.createModelGroup(gltf));
             }, null, error => {
@@ -116,6 +117,12 @@ export default class ModelReader
                     reject(new Error(error as any));
                 }
             })
+        }).then((result)=>{
+            this.loadingManager.itemEnd(url);
+            return result;
+        }, (e)=> {
+            this.loadingManager.itemError(url);
+            throw e;
         });
     }
 

--- a/source/client/io/ModelReader.ts
+++ b/source/client/io/ModelReader.ts
@@ -119,7 +119,7 @@ export default class ModelReader
         });
     }
 
-    protected createModelGroup(gltf): Object3D
+    protected async createModelGroup(gltf): Promise<Object3D>
     {
         const scene: Scene = gltf.scene;
 
@@ -161,6 +161,7 @@ export default class ModelReader
             }
         });
 
+        await this.renderer.views[0].renderer.compileAsync(scene, this.renderer.activeCamera, this.renderer.activeScene);
         return scene;
     }
 }


### PR DESCRIPTION
Fixes #325 and #326 with proper LoadingManager usage.

In the end it's arguably better than before because GLTFLoader counts 1 "item" per GLTF buffer, which generally doesn't make much sense and is a bit too verbose to my taste.

a581341bf5564cfbf0d4b129db2fba36978b4d60 in particular _may_ lead to some unexpected results : Those kind of algorithms are always a bit tricky to get right.

