### PR TITLE
ensure WebDAVProvider.rootPath is a folder

### DIFF
--- a/libs/ff-scene/source/assets/WebDAVProvider.ts
+++ b/libs/ff-scene/source/assets/WebDAVProvider.ts
@@ -70,6 +70,7 @@ export default class WebDAVProvider
     set rootUrl(url: string) {
         this._rootUrl = url;
         this._rootPath = new URL(url).pathname;
+        if(!this._rootPath.endsWith("/")) this._rootPath = this._rootPath.split("/").slice(0, -1).join("/")+"/";
 
         if (ENV_DEVELOPMENT) {
             console.log("WebDAVProvider - rootUrl: %s, rootPath: %s", this.rootUrl, this.rootPath)


### PR DESCRIPTION
Setting up the default WebDAV server, if you create a folder (`cube` in my example) with a dummy scene with it and navigate to `http://localhost:8000/voyager-story-dev.html?document=/cube/scene.svx.json` **WITHOUT** setting the `root` parameter, the scene kinda works but for the asset tree not matching properly.

Easiest way to show this is click `Create` in the Article Task. Nothing is shown until you click somewhere to deselect said article.

I traced it back to `WebDAVProvider.rootPath`, being normally set to `/cube/` but defaults to the value of `ExplorerApplication.props.document`,  here `/cube/scene.svx.json`.

I checked usage of this path and it looks like it's only used in `WebDAVProvider.parseResponse`

Not sure if expecting `rootPath` to always end with a trailing "/" is a valid option though? It doesn't seem to work otherwise anyway? if I set `root=/cube` the scene won't load
