### PR TITLE
allow document.asset.copyright to be an empty string

### DIFF
--- a/source/client/schema/document.ts
+++ b/source/client/schema/document.ts
@@ -53,7 +53,7 @@ export interface IDocumentAsset
 {
     type: "application/si-dpo-3d.document+json";
     version: string;
-    copyright?: string;
+    copyright: string;
     generator?: string;
 }
 

--- a/source/client/schema/json/document.schema.json
+++ b/source/client/schema/json/document.schema.json
@@ -312,7 +312,7 @@
                 "copyright": {
                     "description": "A copyright message to credit the content creator.",
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 0
                 },
                 "generator": {
                     "description": "Tool that generated this presentation description.",


### PR DESCRIPTION
Deleting `document.asset.copyright` in voyager-story makes for a document that fails to validate :

1. Because  `document.asset.copyright` has a `minLength`of 1 but is optional  in `document.schema.json`
2. Because CVDocument.ins.copyright.value is always serialized, even when it is an empty string, which it can be since #285 (well done, me! :wink: )

Both are reasonable, but can't work together.

At first I thought about saving `copyright` only when not empty but then Voyager will always revert back to the default Smithsonian notice on reload (and then will write it on next save), which is not ideal.

So I removed the minLength requirement and marked the property as required to reflect the behavior.
