### PR TITLE
dispose of old document only if it exist

### DIFF
--- a/source/client/applications/ExplorerApplication.ts
+++ b/source/client/applications/ExplorerApplication.ts
@@ -245,7 +245,7 @@ Version: ${ENV_VERSION}
         const oldDocument = this.documentProvider.activeComponent;
         this.documentProvider.createDocument(documentTemplate as any);
         this.evaluateProps();
-        oldDocument.dispose();
+        oldDocument?.dispose();
     }
 
     loadModel(modelPath: string, quality: string)


### PR DESCRIPTION
https://github.com/Smithsonian/dpo-voyager/commit/af6cb9f49c92d28e6fecfb46eb4494d75f3dd013 makes `reloadDocument()` crash the application if called on an uninitialized stack.

The behavior of `reloadDocument` when there is no document to reload is not documented, so it's not strictly speaking a bug.

I'd say `reloadDocument` should check by itself if there is a document to dispose of because :

- that was the original behavior
- The user has no (easy) way to know if there _IS_ a document, `ExplorerApplication.documentProvider` being protected. (one _could_ call `ExplorerApplication.system.getMainComponent(CVDocumentProvider).activeComponent`, but we probably don't want that)

