### PR TITLE
Annotations translation for smithsonian

### DIFF
--- a/assets/language/string.resources.fr.json
+++ b/assets/language/string.resources.fr.json
@@ -41,6 +41,8 @@
   "Material": "Texture",
   "Measure": "Mesure",
   "Measured Distance": "Distance mesurée",
+  "New Annotation": "Nouvelle Annotation",
+  "New Article": "Nouvel Article",
   "No tour selected": "Pas de visite sélectionnée",
   "No tour steps defined": "Pas d'étapes de visites définies",
   "Normals": "Normales",

--- a/source/client/components/CVAnnotationsTask.ts
+++ b/source/client/components/CVAnnotationsTask.ts
@@ -258,6 +258,8 @@ export default class CVAnnotationsTask extends CVTask
 
     protected createAnnotation(position: number[], direction: number[])
     {
+        const languageManager = this.activeDocument.setup.language;
+        const language = languageManager.ins.language.value;
         const annotations = this.activeAnnotations;
         if (!annotations) {
             return;
@@ -274,6 +276,14 @@ export default class CVAnnotationsTask extends CVTask
         const model = annotations.getComponent(CVModel2);
         const annotation = new Annotation(template);
 
+        annotation.language = language;
+        annotation.title = languageManager.getLocalizedString("New Annotation");
+
+        if (languageManager.ins.language.value != ELanguageType[languageManager.defaultLanguage]){
+            //Ensure that there is a title in the default language of the scene
+            const defaultLocalized = languageManager.getLocalizedStringInDefaultLanguage("New Annotation");
+            annotation.titleInLanguage(defaultLocalized, ELanguageType[languageManager.defaultLanguage]);
+        }
         const data = annotation.data;
         data.position = position;
         data.direction = direction;

--- a/source/client/components/CVLanguageManager.ts
+++ b/source/client/components/CVLanguageManager.ts
@@ -40,6 +40,8 @@ export default class CVLanguageManager extends Component
     static readonly text: string = "Language";
     static readonly icon: string = "";
 
+    private _sceneDefaultLanguage:TLanguageType;
+    private _defaultLanguageTranslations: ITranslation = {};
     private _activeLanguages: {[key in TLanguageType]?: ILanguageOption} = {};
     private _translations: ITranslation = {};
 
@@ -73,6 +75,9 @@ export default class CVLanguageManager extends Component
     }
     get activeLanguages() {
         return Object.values(this._activeLanguages);
+    }
+    get defaultLanguage(){
+        return this._sceneDefaultLanguage;
     }
 
     /**
@@ -123,7 +128,9 @@ export default class CVLanguageManager extends Component
         data = data || {} as ILanguage;
 
         const language = ELanguageType[data.language || "EN"] ?? ELanguageType[DEFAULT_LANGUAGE];
-
+        this._sceneDefaultLanguage = data.language || "EN";
+        this.assetReader.getSystemJSON("language/string.resources." + this._sceneDefaultLanguage.toLowerCase() + ".json").then(json => 
+            {this._defaultLanguageTranslations = json});
         ins.language.setValue(language);
     }
 
@@ -157,6 +164,23 @@ export default class CVLanguageManager extends Component
         return dictionary[text] || text;
     }
 
+    getLocalizedStringInDefaultLanguage(text: string): string
+    {
+        const dictionary = this._defaultLanguageTranslations;
+        if(dictionary === undefined) {
+            return text;
+        }
+        if(ENV_DEVELOPMENT && typeof dictionary[text] === "undefined" 
+            && this._sceneDefaultLanguage != DEFAULT_LANGUAGE
+        ){
+            console.groupCollapsed(`Missing translation string "${text}" for "${ELanguageType[this.ins.language.value]}`);
+            console.trace();
+            console.groupEnd();
+        }
+        return dictionary[text] || text;
+    }
+
+    
     protected updateLanguage = (language: ELanguageType) => 
     {
         const { ins, outs } = this;

--- a/source/client/models/Annotation.ts
+++ b/source/client/models/Annotation.ts
@@ -31,7 +31,7 @@ export type IAnnotationDisposeEvent = IDocumentDisposeEvent<Annotation>;
 export default class Annotation extends Document<IAnnotation, IAnnotation>
 {
     static readonly defaultColor = [ 0, 0.61, 0.87 ];
-    private _language : ELanguageType = ELanguageType.EN;
+    private _language : ELanguageType = ELanguageType[DEFAULT_LANGUAGE];
     private _leadChanged : boolean = false;
 
     get title() {
@@ -46,6 +46,12 @@ export default class Annotation extends Document<IAnnotation, IAnnotation>
         this.data.titles[ELanguageType[this.language]] = inTitle;
         this.update();
     }
+    
+    titleInLanguage(inTitle: string, language: ELanguageType) {
+        this.data.titles[ELanguageType[language]] = inTitle;
+        this.update();
+    }
+
     get lead() {
         // TODO: Temporary - remove when single string properties are phased out
         if(Object.keys(this.data.leads).length === 0) {

--- a/source/client/ui/story/AnnotationList.ts
+++ b/source/client/ui/story/AnnotationList.ts
@@ -19,7 +19,7 @@ import { customElement, property, html } from "@ff/ui/CustomElement";
 import List from "@ff/ui/List";
 
 import Annotation from "../../models/Annotation";
-import { DEFAULT_LANGUAGE } from "client/schema/common";
+import {ELanguageType} from "client/schema/common";
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -37,6 +37,12 @@ class AnnotationList extends List<Annotation>
     @property({ attribute: false })
     selectedItem: Annotation = null;
 
+    @property({type: ELanguageType})
+    currentLanguage: ELanguageType = ELanguageType.EN;
+
+    @property({type: ELanguageType})
+    defaultLanguage: ELanguageType = ELanguageType.EN;
+
     protected firstConnected()
     {
         super.firstConnected();
@@ -45,7 +51,14 @@ class AnnotationList extends List<Annotation>
 
     protected renderItem(item: Annotation)
     {
-        return html`<div class="ff-flex-row ff-group"><div class="sv-task-item">${item.data.titles[DEFAULT_LANGUAGE]}</div><div class="sv-task-item sv-item-border-l">${item.title}</div></div>`;
+        let renderedItem;
+        
+        if (this.currentLanguage!=this.defaultLanguage){
+            renderedItem = html`<div class="ff-flex-row ff-group"><div class="sv-task-item">${item.data.titles[this.defaultLanguage]}</div><div class="sv-task-item sv-item-border-l">${item.data.titles[this.currentLanguage]}</div></div>`
+        } else {
+            renderedItem = html`<div class="ff-flex-row ff-group"><div class="sv-task-item-full">${item.data.titles[this.defaultLanguage]}</div></div>`
+        }
+        return renderedItem;
     }
 
     protected isItemSelected(item: Annotation)

--- a/source/client/ui/story/AnnotationsTaskView.ts
+++ b/source/client/ui/story/AnnotationsTaskView.ts
@@ -131,6 +131,7 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
                 <sv-property-view .property=${inProps.tags}></sv-property-view>
                 <sv-property-view .property=${inProps.title}></sv-property-view>
                 <div class="sv-label" style="${overLimit ? "color: red" : ""}" @click=${(e)=>this.onClickLimit(e)}>Lead&nbsp&nbsp&nbsp${this._leadCharCount}/${limitText}</div>
+                ${defaultLanguage!=currentLanguage? html`<div class="text-to-translate">${annotation.data.leads[defaultLanguage]}</div>`:null}
                 <ff-text-edit name="lead" text=${inProps.lead.value} rows=3 maxLength=${this._leadLimit} @change=${this.onTextEdit}></ff-text-edit>
             </div>
             <div class="sv-label">View Point</div>

--- a/source/client/ui/story/AnnotationsTaskView.ts
+++ b/source/client/ui/story/AnnotationsTaskView.ts
@@ -32,7 +32,7 @@ import { ISelectAnnotationEvent } from "./AnnotationList";
 import CVAnnotationView from "../../components/CVAnnotationView";
 import CVAnnotationsTask, { EAnnotationsTaskMode } from "../../components/CVAnnotationsTask";
 import { TaskView } from "../../components/CVTask";
-import { ELanguageStringType, DEFAULT_LANGUAGE } from "client/schema/common";
+import { ELanguageStringType, ELanguageType } from "client/schema/common";
 
 import sanitizeHtml from 'sanitize-html';
 import CVMediaManager from "client/components/CVMediaManager";
@@ -81,6 +81,8 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
         const node = this.activeNode;
         const annotations = node && node.getComponent(CVAnnotationView, true);
         const languageManager = this.activeDocument.setup.language;
+        const defaultLanguage = languageManager.defaultLanguage;
+        const currentLanguage = ELanguageType[languageManager.ins.language.value];
 
         if (!annotations) {
             // set cursor to grab
@@ -138,19 +140,16 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
                 <ff-button text="Delete" ?disabled=${!annotation.data.viewId.length} icon="trash" @click=${this.onDeleteView}></ff-button>
             </div>
         </div>` : null;
-
-        return html`<div class="sv-commands">
-            <ff-button text="Select" icon="select" index=${EAnnotationsTaskMode.Off} selectedIndex=${modeProp.value} @click=${this.onClickMode}></ff-button>       
-            <ff-button text="Move" icon="move" index=${EAnnotationsTaskMode.Move} selectedIndex=${modeProp.value} @click=${this.onClickMode}></ff-button>       
-            <ff-button text="Create" icon="create" index=${EAnnotationsTaskMode.Create} selectedIndex=${modeProp.value} @click=${this.onClickMode}></ff-button>       
-            <ff-button text="Delete" icon="trash" ?disabled=${!annotation} @click=${this.onClickDelete}></ff-button>  
-        </div>
-        <div class="ff-flex-item-stretch">
+        
+        let annotationListRendered;
+        // Display a column in each language if current language is not the default one.
+        if(defaultLanguage!=currentLanguage){
+        annotationListRendered = html`<div class="ff-flex-item-stretch">
             <div class="ff-flex-column ff-fullsize">
-                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[DEFAULT_LANGUAGE]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${languageManager.nameString()}</div></div>
+                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item">${ELanguageStringType[defaultLanguage]}</div><div class="sv-panel-header sv-task-item sv-item-border-l">${ELanguageStringType[currentLanguage]}</div></div>
                 <div class="ff-splitter-section" style="flex-basis: 30%">
                     <div class="ff-scroll-y ff-flex-column">
-                        <sv-annotation-list .data=${annotationList} .selectedItem=${annotation} @select=${this.onSelectAnnotation}></sv-annotation-list>
+                        <sv-annotation-list .data=${annotationList} .selectedItem=${annotation} .currentLanguage=${currentLanguage} .defaultLanguage=${defaultLanguage} @select=${this.onSelectAnnotation} ></sv-annotation-list>
                     </div>
                 </div>
                 <ff-splitter direction="vertical"></ff-splitter>
@@ -158,7 +157,33 @@ export default class AnnotationsTaskView extends TaskView<CVAnnotationsTask>
                     ${detailView}
                 </div>
             </div>
-        </div>`;
+        </div>`
+        }
+        else {
+            // else display only one column
+            annotationListRendered = html`<div class="ff-flex-item-stretch">
+            <div class="ff-flex-column ff-fullsize">
+                <div class="ff-flex-row ff-group"><div class="sv-panel-header sv-task-item-full">${ELanguageStringType[defaultLanguage]}</div></div>
+                <div class="ff-splitter-section" style="flex-basis: 30%">
+                    <div class="ff-scroll-y ff-flex-column">
+                        <sv-annotation-list .data=${annotationList} .selectedItem=${annotation} .currentLanguage=${currentLanguage} .defaultLanguage=${defaultLanguage} @select=${this.onSelectAnnotation} ></sv-annotation-list>
+                    </div>
+                </div>
+                <ff-splitter direction="vertical"></ff-splitter>
+                <div class="ff-splitter-section" style="flex-basis: 70%">
+                    ${detailView}
+                </div>
+            </div>
+        </div>`
+    
+        }
+        return html`<div class="sv-commands">
+            <ff-button text="Select" icon="select" index=${EAnnotationsTaskMode.Off} selectedIndex=${modeProp.value} @click=${this.onClickMode}></ff-button>       
+            <ff-button text="Move" icon="move" index=${EAnnotationsTaskMode.Move} selectedIndex=${modeProp.value} @click=${this.onClickMode}></ff-button>       
+            <ff-button text="Create" icon="create" index=${EAnnotationsTaskMode.Create} selectedIndex=${modeProp.value} @click=${this.onClickMode}></ff-button>       
+            <ff-button text="Delete" icon="trash" ?disabled=${!annotation} @click=${this.onClickDelete}></ff-button>  
+        </div>
+        ${annotationListRendered}`;
     }
 
     protected onTextEdit(event: ILineEditChangeEvent)

--- a/source/client/ui/story/styles.scss
+++ b/source/client/ui/story/styles.scss
@@ -43,6 +43,15 @@
   color: $color-text;
 }
 
+.text-to-translate {
+  background-color: #272727;
+  font-style: italic;
+  color: #a0a0a0;
+  border-left: #a0a0a0 solid 1px;
+  padding-left: 4px;
+  margin-bottom: 4px;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // EXPLORER OVERRIDES
 


### PR DESCRIPTION
These changes aim at making it easier to translate annotations, especially if English is not the default language of the scene.

The following improvements are included:
- When working in the default language of a scene, the table shows only one column instead of the same one twice 
![image](https://github.com/user-attachments/assets/54fcb454-7c33-48ae-b6cb-5a385e3b0475)
- When working in a secondary language, show the default language (here Spanish) on the left, instead of only English
![image](https://github.com/user-attachments/assets/e81817da-030b-43ed-80d8-cf2fd25c6a8e)
- When working in a secondary language, show the default language lead above the lead field
![image](https://github.com/user-attachments/assets/019e4c89-eb84-45e6-a21e-f7f95d75e4d2)

This preserves the behavior of always having at least a title in the default language (not necessarily English)