### PR TITLE
add navigation role to sv-task-bar

### DIFF
--- a/source/client/ui/story/TaskBar.ts
+++ b/source/client/ui/story/TaskBar.ts
@@ -55,6 +55,7 @@ export default class TaskBar extends SystemView
     protected firstConnected()
     {
         this.classList.add("sv-task-bar");
+        this.setAttribute("role", "navigation");
     }
 
     protected connected()


### PR DESCRIPTION
trivial patch to add a `role="navigation"` to `<sv_task-bar>`, which helps reliably targetting task bar buttons in automated tests.

Should also help usage with other assistive tools, possibly?