### PR TITLE
Fix using Italian as the primary language of a scene

### DIFF
--- a/source/client/schema/json/setup.schema.json
+++ b/source/client/schema/json/setup.schema.json
@@ -226,7 +226,7 @@
                 "language": {
                     "type": "string",
                     "enum": [
-                        "EN", "ES", "DE", "NL", "JA", "FR", "HAW"
+                        "EN", "ES", "DE", "NL", "JA", "FR", "HAW", "IT"
                     ]
                 }
             }


### PR DESCRIPTION
The schema validation is currently failing if Italian is the primary language of a scene.