### PR TITLE
CVEnvironment memory leak. Fix #185

### DIFF
--- a/libs/ff-scene/source/components/CRenderGraph.ts
+++ b/libs/ff-scene/source/components/CRenderGraph.ts
@@ -36,6 +36,7 @@ export default class CRenderGraph extends CGraph implements ICObject3D
         super(node, id);
 
         this._object3D = new Object3D();
+        this._object3D.name ="Graph";
         this._object3D.matrixAutoUpdate = false;
     }
 

--- a/libs/ff-scene/source/components/CTransform.ts
+++ b/libs/ff-scene/source/components/CTransform.ts
@@ -164,6 +164,8 @@ export default class CTransform extends CHierarchy implements ICObject3D
 
     protected createObject3D()
     {
-        return new Object3D();
+        let obj = new Object3D();
+        obj.name = "Transform";
+        return obj;
     }
 }

--- a/source/client/annotations/CircleSprite.ts
+++ b/source/client/annotations/CircleSprite.ts
@@ -71,6 +71,8 @@ export default class CircleSprite extends AnnotationSprite
     dispose()
     {
         this.offset = null;
+        this.anchorMesh?.geometry.dispose();
+        (this.anchorMesh?.material as MeshBasicMaterial).dispose();
         this.anchorMesh = null;
 
         super.dispose();

--- a/source/client/annotations/ExtendedSprite.ts
+++ b/source/client/annotations/ExtendedSprite.ts
@@ -64,6 +64,12 @@ export default class ExtendedSprite extends AnnotationSprite
         this.update();
     }
 
+    dispose(){
+        this.stemLine.geometry.dispose();
+        (this.stemLine.material as LineBasicMaterial).dispose();
+        super.dispose();
+    }
+
     update()
     {
         const annotation = this.annotation.data;

--- a/source/client/annotations/StandardSprite.ts
+++ b/source/client/annotations/StandardSprite.ts
@@ -111,6 +111,12 @@ export default class StandardSprite extends AnnotationSprite
     {
         return new StandardAnnotation(this);
     }
+
+    dispose(){
+        super.dispose();
+        this.stemLine.geometry.dispose();
+        (this.stemLine.material as LineBasicMaterial).dispose();
+    }
 }
 
 AnnotationFactory.registerDefaultType(StandardSprite);

--- a/source/client/components/CVAnnotationView.ts
+++ b/source/client/components/CVAnnotationView.ts
@@ -216,6 +216,7 @@ export default class CVAnnotationView extends CObject3D
         this.language.outs.activeLanguage.on("value", this.updateLanguage, this);
 
         this.object3D = new HTMLSpriteGroup();
+        this.object3D.name = "AnnotationView";
     }
 
     setActiveAnnotationById(id: string)

--- a/source/client/components/CVModel2.ts
+++ b/source/client/components/CVModel2.ts
@@ -171,6 +171,7 @@ export default class CVModel2 extends CObject3D
         super(node, id);
 
         this.object3D = new Group();
+        this.object3D.name = "Model";
     }
 
     get snapshotProperties() {

--- a/source/client/components/CVStaticAnnotationView.ts
+++ b/source/client/components/CVStaticAnnotationView.ts
@@ -84,6 +84,7 @@ export default class CVStaticAnnotationView extends CObject3D
 
         this.object3D = new HTMLSpriteGroup();
         (this.object3D as HTMLSpriteGroup).setVisible(false);
+        this.object3D.name ="StaticAnnotationView"
     }
 
 

--- a/source/client/components/CVTape.ts
+++ b/source/client/components/CVTape.ts
@@ -93,6 +93,7 @@ export default class CVTape extends CObject3D
         super(node, id);
 
         this.object3D = new Group();
+        this.object3D.name = "Tape";
 
         this.startPin = new Pin();
         this.startPin.matrixAutoUpdate = false;


### PR DESCRIPTION
I think I finally got to the bottom of https://github.com/Smithsonian/dpo-voyager/issues/185.

There were a number of issues that were generally not visible unless you reload document with **very heavy scenes**, every few seconds over the course of many hours (days). I suspect the shaders leak from https://github.com/Smithsonian/dpo-voyager/pull/324 also had a part in it.

There were two remaining issues : 

- One negligible leak of geometries through bad annotation sprites cleanup (aa59696dd148c898e5abd9abefc94236a3bbd867)
- One larger one from `CVEnvironment`


The one from annotations is simple and self explanatory, however  the environment map leak is a bit tricky. It _seems_ what was happening is when you assigned a `Texture`  to `scene.environment`, the renderer would create a `CubeCamera` and a cube geometry to render it. If environment was then reassigned to something else or set to null, the texture would be kept in memory (or forcefully reuploaded after a `dispose()`call) by the renderer.

I found no way to access this internal texture reference so the best fix I could think of was to explicitly allocate and free those resources in `CVEnvironment`. I used a [PMREMGenerator](https://threejs.org/docs/?q=PMRE#api/en/extras/PMREMGenerator) as it's supposedly better at generating environment textures than a CubeCamera.


Third commit is some labels-corrections on  `Object3D`s that I did while trying to troubleshoot the memory leak. I figured it wouldn't hurt to keep them?