### PR TITLE
Articles languages on reloadDocument

### DIFF
--- a/source/client/components/CVArticlesTask.ts
+++ b/source/client/components/CVArticlesTask.ts
@@ -330,6 +330,7 @@ export default class CVArticlesTask extends CVTask
             ins.tags.setValue("", true);
             ins.uri.setValue("", true);
             outs.article.setValue(null);
+            ins.edit.set();
         }
     }
 

--- a/source/client/components/CVMeta.ts
+++ b/source/client/components/CVMeta.ts
@@ -84,6 +84,7 @@ export default class CVMeta extends Component
                 Object.keys(article.data.titles).forEach( key => {
                    this.language.addLanguage(ELanguageType[key]);
                 });
+                article.language = this.language.outs.activeLanguage.value;
             });
         }
         if (data.audio) {


### PR DESCRIPTION
Some article languages troubles that —as far as I know— only happens when reloading a document.

- d4381d4c04822dabf7d4e06c7e707e919c19c929 : In a normal sequence, `CVReader.updateLanguage()` is triggered first in English, then `CVReader.updateArticles()` then (if necessary) `CVReader.updateLanguage()` again if scene language is not english. When reloading a scene, the active language doesn't change so the article's languages are out of sync. I think the best solution is to initialize the articles using `CVLanguageManager.outs.language` so this won't happen.
- 11fe7f631812ae393cd990585fd8a63e04421222 Article editor wasn't updated when reloading the scene. Since selection is reset, it should be reset too. Since its update is conditional, we just have to force-update `ins.edit` to trigger it.

Both changes concerns edge cases that would not surface in "normal operation", but they also should be pretty innocuous.
