### PR TITLE
Async validate

### DIFF
--- a/source/client/components/CVDocument.ts
+++ b/source/client/components/CVDocument.ts
@@ -181,7 +181,10 @@ export default class CVDocument extends CRenderGraph
     async validateDocument(documentData: IDocument){
         /** Workers are a "baseline" feature since 2015 so this shouldn't happen much */
         if(!window.Worker) return console.warn("Couldn't validate document: web workers are not supported");
-        let worker = _worker ??= new Worker(new URL("../io/validateDocument.ts", import.meta.url));
+        let worker = _worker ??= new Worker(
+             /* webpackChunkName: "validateDocument" */ 
+            new URL("../io/validateDocument.ts", import.meta.url)
+        );
         worker.postMessage(documentData);
         return new Promise<void>((resolve, reject)=>{
             worker.onmessage = ((ev:MessageEvent<boolean>)=>{

--- a/source/client/components/CVDocument.ts
+++ b/source/client/components/CVDocument.ts
@@ -25,8 +25,6 @@ import { Dictionary } from "@ff/core/types";
 import { IDocument } from "client/schema/document";
 import { EDerivativeQuality } from "client/schema/model";
 
-import DocumentValidator from "../io/DocumentValidator";
-
 import NVNode, { INodeComponents } from "../nodes/NVNode";
 import NVScene from "../nodes/NVScene";
 
@@ -54,7 +52,6 @@ export default class CVDocument extends CRenderGraph
     static readonly mimeType = "application/si-dpo-3d.document+json";
     static readonly version = "1.0";
 
-    protected static readonly validator = new DocumentValidator();
 
     protected titles: Dictionary<string> = {};
     protected intros: Dictionary<string> = {};
@@ -190,10 +187,6 @@ export default class CVDocument extends CRenderGraph
     {
         if (ENV_DEVELOPMENT) {
             console.log("CVDocument.openDocument - assetPath: %s, mergeParent: %s", assetPath, mergeParent);
-        }
-
-        if (!CVDocument.validator.validate(documentData)) {
-            throw new Error("document schema validation failed");
         }
 
         if (!mergeParent) {

--- a/source/client/io/Worker.ts
+++ b/source/client/io/Worker.ts
@@ -2,24 +2,39 @@
 /**
  * Wrapper around the global Worker constructor to load CORS resources
  */
-export class CORSWorker{
-    url: string|URL;
-    options ?:WorkerOptions;
+export class CORSWorker<T = any, U = any>{
+    private _queue :[(res:T)=>unknown, (err:Error)=>unknown][] = [];
+    private _worker: globalThis.Worker;
     // Have this only to trick Webpack into properly transpiling
     // the url address from the component which uses it
-    constructor(url: string | URL, options?: WorkerOptions) {
-        this.url = url;
-        this.options = options;
+    constructor(scriptURL: string | URL, options?: WorkerOptions) {
+      const b = new Blob([`importScripts("${scriptURL.toString()}");`], {
+          type: 'application/javascript',
+      });
+      const url = URL.createObjectURL(b);
+      try{
+        this._worker = new Worker(url, options);
+        this._worker.onmessage = (ev: MessageEvent<T>)=>{
+          let [resolve] = this._queue.shift();
+          resolve(ev.data)
+        }
+        this._worker.onerror = (ev: ErrorEvent)=>{
+          let [_, reject] = this._queue.shift();
+          reject(new Error(ev.message ?? "Unknown Web Worker error"));
+        }
+      }finally{
+        URL.revokeObjectURL(url);
+      }
     }
 
-    async createWorker(): Promise<Worker> {
-        const f = await fetch(this.url);
-        const t = await f.text();
-        const b = new Blob([t], {
-            type: 'application/javascript',
-        });
-        const url = URL.createObjectURL(b);
-        const worker = new Worker(url, this.options);
-        return worker;
+    getWorker(): Worker {
+      return this._worker;
+    }
+
+    async send(data: U):Promise<T>{
+      return new Promise((resolve, reject)=>{
+        this._queue.push([resolve, reject]);
+        this._worker.postMessage(data);
+      });
     }
 }

--- a/source/client/io/Worker.ts
+++ b/source/client/io/Worker.ts
@@ -1,0 +1,25 @@
+
+/**
+ * Wrapper around the global Worker constructor to load CORS resources
+ */
+export class CORSWorker{
+    url: string|URL;
+    options ?:WorkerOptions;
+    // Have this only to trick Webpack into properly transpiling
+    // the url address from the component which uses it
+    constructor(url: string | URL, options?: WorkerOptions) {
+        this.url = url;
+        this.options = options;
+    }
+
+    async createWorker(): Promise<Worker> {
+        const f = await fetch(this.url);
+        const t = await f.text();
+        const b = new Blob([t], {
+            type: 'application/javascript',
+        });
+        const url = URL.createObjectURL(b);
+        const worker = new Worker(url, this.options);
+        return worker;
+    }
+}

--- a/source/client/io/validateDocument.ts
+++ b/source/client/io/validateDocument.ts
@@ -26,30 +26,28 @@ import setupSchema from "client/schema/json/setup.schema.json";
 import type { IDocument } from "client/schema/document";
 
 ////////////////////////////////////////////////////////////////////////////////
+const schemaValidator = new AjvCore({
+    schemas: [
+        documentSchema,
+        commonSchema,
+        metaSchema,
+        modelSchema,
+        setupSchema,
+    ],
+    allErrors: true
+});
 
 /**
  * Web worker that validates a document data against the JSON-schema
  */
-onmessage = ({data}:MessageEvent<IDocument>) => {
-    console.debug("Message received from main script");
-    const schemaValidator = new AjvCore({
-        schemas: [
-            documentSchema,
-            commonSchema,
-            metaSchema,
-            modelSchema,
-            setupSchema,
-        ],
-        allErrors: true
-    });
-
+onmessage = ({data}:MessageEvent<IDocument|undefined>) => {
     const validateDocument = schemaValidator.getSchema(
         "https://schemas.3d.si.edu/voyager/document.schema.json"
     );
-
     if (!validateDocument(data)) {
-        throw new Error(schemaValidator.errorsText(
+        postMessage(schemaValidator.errorsText(
             validateDocument.errors, { separator: ", ", dataVar: "document" }));
+    }else{
+        postMessage(undefined);
     }
-    postMessage(true);
 };

--- a/source/client/tsconfig.json
+++ b/source/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es2017",
-        "module": "es2015",
+        "module": "es2020",
         "sourceMap": true,
         //"strict": true,
         "jsx": "react",

--- a/source/client/webpack.config.js
+++ b/source/client/webpack.config.js
@@ -163,7 +163,10 @@ module.exports = function(env, argv)
             minimizer: [
                 new TerserPlugin({ parallel: true }),
                 new CSSMinimizerPlugin(),
-            ]
+            ],
+            splitChunks: {
+                chunks: ()=>false, //Disable common chunks splitting
+            }
         },
 
         plugins: [


### PR DESCRIPTION
As discussed in https://github.com/Smithsonian/dpo-voyager/discussions/317, I want to speed up initial scene load by moving the scene validation off the main thread.

This change moves document validation over to a Web Worker. The gain is twofold: 

#### schema-parsing (which is quite CPU-heavy) should now happen off the main thread

main-thread parsing took ~200ms for a simple scene

starting the worker seems to take no measurable time. further work is non-blocking

#### schema data and the validation library are no longer included in the main bundle

Loading is asynchronous and the main bundle is 140kb slimmer.

### Optimization

If we want to fully replicate existing behavior it is possible to force the application to crash when schema validation fails by throwing an error on failure. Not sure a crash is desirable as long as we report the error.

For the error reporting I'm thinking a Notification might not be visible enough and it may be preferable to open a dialog box? The error messages can get quite long and it might be preferable to have some space to show them without having users open the browser console?

Here we are starting a Web Worker once and it will stay idle forever. We could instead start a short-lived worker on each `openDocument` call. Not sure what would be best overall.