### PR TITLE
Extract PropertyPercent

### DIFF
--- a/libs/ff-scene/source/components/CCamera.ts
+++ b/libs/ff-scene/source/components/CCamera.ts
@@ -34,11 +34,11 @@ export default class CCamera extends CObject3D
         rotation: types.Vector3("Transform.Rotation"),
         order: types.Enum("Transform.Order", ERotationOrder, ERotationOrder.ZYX),
         projection: types.Enum("Projection.Type", EProjection, EProjection.Perspective),
-        fov: types.Number("Projection.FovY", 52),
-        size: types.Number("Projection.Size", 20),
-        zoom: types.Number("Projection.Zoom", 1),
-        near: types.Number("Frustum.ZNear", 0.01),
-        far: types.Number("Frustum.ZFar", 10000),
+        fov: types.Number("Projection.FovY", {preset: 52, step: 0.1}),
+        size: types.Number("Projection.Size", {preset: 20, step: 0.1}),
+        zoom: types.Number("Projection.Zoom", {preset: 1, step: 0.1}),
+        near: types.Number("Frustum.ZNear", {preset: 0.01, step: 0.01}),
+        far: types.Number("Frustum.ZFar", {preset: 10000, step: 1}),
     };
 
     ins = this.addInputs<CObject3D, typeof CCamera.camIns>(CCamera.camIns);

--- a/libs/ff-scene/source/components/CFloor.ts
+++ b/libs/ff-scene/source/components/CFloor.ts
@@ -16,7 +16,7 @@ export default class CFloor extends CObject3D
 
     protected static readonly floorIns = {
         position: types.Vector3("Floor.Position", [ 0, -25, 0 ]),
-        radius: types.Number("Floor.Radius", 50),
+        radius: types.Number("Floor.Radius", {preset: 50, step: 1}),
         color: types.ColorRGB("Floor.Color", [ 0.6, 0.75, 0.8 ]),
         opacity: types.Percent("Floor.Opacity", 0.5),
         castShadow: types.Boolean("Shadow.Cast"),

--- a/libs/ff-scene/source/components/CLight.ts
+++ b/libs/ff-scene/source/components/CLight.ts
@@ -33,13 +33,15 @@ export default class CLight extends CObject3D
         intensity: types.Number("Light.Intensity", {
             preset:1,
             min: 0,
+            step: 0.1
         }),
         shadowEnabled: types.Boolean("Shadow.Enabled"),
         shadowResolution: types.Enum("Shadow.Resolution", EShadowMapResolution, EShadowMapResolution.Medium),
-        shadowBlur: types.Number("Shadow.Blur", 1),
+        shadowBlur: types.Number("Shadow.Blur", {preset: 1, step: 0.1}),
         shadowIntensity: types.Number("Shadow.Intensity", {
             preset:1,
             min: 0,
+            step: 0.1
         })
     };
 

--- a/libs/ff-scene/source/components/CPointLight.ts
+++ b/libs/ff-scene/source/components/CPointLight.ts
@@ -22,7 +22,7 @@ export default class CPointLight extends CLight
     protected static readonly pointLightIns = {
         position: types.Vector3("Light.Position"),
         distance: types.Number("Light.Distance", {preset: 0, min: 0}),
-        decay: types.Number("Light.Decay", {preset: 1, min: 0}),
+        decay: types.Number("Light.Decay", {preset: 1, min: 0, step: 1}),
     };
 
     ins = this.addInputs<CLight, typeof CPointLight["pointLightIns"]>(CPointLight.pointLightIns);

--- a/source/client/ui/explorer/styles.scss
+++ b/source/client/ui/explorer/styles.scss
@@ -1318,7 +1318,9 @@ $tour-entry-indent: 12px;
     }
   }
 
-
+  &.sv-property-percent{
+    @extend .sv-property, .sv-property-number;
+  }
 
   &.sv-property-slider {
     flex: 0 2 180px;

--- a/source/client/ui/properties/PropertyNumber.ts
+++ b/source/client/ui/properties/PropertyNumber.ts
@@ -94,7 +94,14 @@ export default class PropertyNumber extends PropertyBase
         const min = schema.min;
         const max = schema.max;
         const bounded = isFinite(min) && isFinite(max);
-        const value = this.value;
+        const value: number = this.value;
+        let display: string;
+        if (isFinite(value)) {
+            let s = value.toFixed(3);
+            display = s.replace(/\.?0+$/, "");
+        } else {
+            display = value > 0 ? "inf" : "-inf";
+        }
 
         return html`
             <label class="ff-label ff-off">${name}</label>
@@ -105,7 +112,7 @@ export default class PropertyNumber extends PropertyBase
                     step=${schema.step ?? ""}
                     min=${min ?? ""}
                     max=${max ?? ""}
-                    .value=${value}
+                    .value=${display}
                     @change=${this.onChange}
                     @focus=${(e)=>{ e.target.select();}}
                     @keypress=${(e)=>{if(e.key === "Enter"){e.target.blur();}}}

--- a/source/client/ui/properties/PropertyPercent.ts
+++ b/source/client/ui/properties/PropertyPercent.ts
@@ -23,8 +23,8 @@ import PropertyBase from "./PropertyBase";
 
 ////////////////////////////////////////////////////////////////////////////////
 
-@customElement("sv-property-number")
-export default class PropertyNumber extends PropertyBase
+@customElement("sv-property-percent")
+export default class PropertyPercent extends PropertyBase
 {
     type = "number";
 
@@ -95,21 +95,25 @@ export default class PropertyNumber extends PropertyBase
         const max = schema.max;
         const bounded = isFinite(min) && isFinite(max);
         const value = this.value;
+        let text :string;
+        text = this.setPrecision(value);
 
         return html`
             <label class="ff-label ff-off">${name}</label>
             <div class="sv-property-field">
                 ${bounded? html`<span class="ff-off ff-bar" style="width:${ 100*(value - min) / (max - min)}%;"></span>`:null}
                 <input ?disabled=${this.ariaDisabled === "true"} class="ff-input"
-                    type="number"
+                    type="text"
+                    pattern="[+\\-]?([0-9.]+|inf)%?"
                     step=${schema.step ?? ""}
                     min=${min ?? ""}
                     max=${max ?? ""}
-                    .value=${value}
+                    .value=${text}
                     @change=${this.onChange}
                     @focus=${(e)=>{ e.target.select();}}
                     @keypress=${(e)=>{if(e.key === "Enter"){e.target.blur();}}}
                 >
+                <span class="ff-off ff-unit">%</span>
             </div>
         `;
     }
@@ -123,6 +127,22 @@ export default class PropertyNumber extends PropertyBase
         }
     }
 
+    protected setPrecision(value: number) : string {
+        const schema = this.property.schema;
+        let text :string;
+
+        if(!isFinite(value)){
+            text = value > 0 ? "inf" : "-inf";
+        }
+        else{
+            const precision = schema.precision !== undefined
+            ? schema.precision : PropertyField.defaultPrecision;
+
+            text = (value * 100).toFixed(precision - 2);
+        }
+        return text;
+    }
+
     protected onChange = (event: Event) => {
         let text = (event.target as HTMLInputElement).value;
 
@@ -130,7 +150,18 @@ export default class PropertyNumber extends PropertyBase
             this.setValue(text[0] === "-" ? -Infinity : Infinity);
             return;
         }
-        let value = parseFloat(text);
+        let value :number;
+        if(text.endsWith("%")) {
+            text = text.slice(0, -1);
+        }
+        value = +text / 100;
+
+        // Handle special case where precision-rounded number will match current widget text.
+        // Lit sees it as unchanged and will not re-render the widget.
+        const currentValueText = this.setPrecision(this.value);
+        if(this.setPrecision(value) == currentValueText) {
+            (event.target as HTMLInputElement).value = currentValueText;
+        }
 
         if(!isFinite(value)) {
             value = 0;

--- a/source/client/ui/story/PropertyView.ts
+++ b/source/client/ui/story/PropertyView.ts
@@ -29,6 +29,7 @@ import "../properties/PropertyBoolean";
 import "../properties/PropertyString";
 import "../properties/PropertySlider";
 import "../properties/PropertyNumber";
+import "../properties/PropertyPercent";
 import "../properties/PropertyOptions";
 import "../properties/PropertyEvent";
 
@@ -98,7 +99,11 @@ export default class PropertyView extends CustomElement
         }else if(property.type === "string"){
             return html`<sv-property-string aria-disabled=${disabled} name=${label} .property=${property}></sv-property-string>`
         }else if(property.type === "number"){
-            return html`<sv-property-number aria-disabled=${disabled} name=${label} .property=${property}></sv-property-number>`
+            if(schema.percent){
+                return html`<sv-property-percent aria-disabled=${disabled} name=${label} .property=${property}></sv-property-percent>`
+            }else{
+                return html`<sv-property-number aria-disabled=${disabled} name=${label} .property=${property}></sv-property-number>`
+            }
         }else{
             console.warn("Unhandled property :", property.name);
             return html`<div class="sv-property-name">${label}</div><div class="sv-property-group">${property.value} (not editable)</div>`;

--- a/source/client/ui/story/PropertyView.ts
+++ b/source/client/ui/story/PropertyView.ts
@@ -93,13 +93,13 @@ export default class PropertyView extends CustomElement
                 return html`${headerElement}<div class="sv-property-group">${fields}</div>`;
             } else if (schema.percent){
                 return html`<sv-property-percent aria-disabled=${disabled} name=${label} .property=${property}></sv-property-percent>`
+            } else if (schema.options) {
+                return html`<sv-property-options aria-disabled=${disabled} dropdown name=${label} .property=${property}></sv-property-options>`;
             } else {
                 return html`<sv-property-number aria-disabled=${disabled} name=${label} .property=${property}></sv-property-number>`
             }
         }else if (schema.event) {
             return html`<sv-property-event aria-disabled=${disabled} name=${label} .property=${property}></sv-property-event>`;
-        }else if (schema.options) {
-            return html`<sv-property-options aria-disabled=${disabled} dropdown name=${label} .property=${property}></sv-property-options>`;
         }else if(property.type === "boolean"){
             return html`<sv-property-boolean aria-disabled=${disabled} name=${label} .property=${property}></sv-property-boolean>`;
         }else if(property.type === "string"){

--- a/source/client/ui/story/PropertyView.ts
+++ b/source/client/ui/story/PropertyView.ts
@@ -78,18 +78,24 @@ export default class PropertyView extends CustomElement
             console.error("Unsupported property : ", property);
             return null;
         }
-        if(property.type === "number" && property.schema.semantic === "color"){
-            return html`<sv-property-color ?aria-disabled=${disabled} name=${label} .property=${property}></sv-property-color>`;
-        }else if (property.type === "number" && property.isArray()) {
-            let fields = [];
-            for (let i = 0; i < property.elementCount; ++i) {
-                
-                let index_disabled = disabled || this.property.hasInLinks(i);
-                const fieldLabel = property.schema.labels?.[i] ?? _defaultLabels[i];
-                fields.push(html`<sv-property-number aria-disabled=${index_disabled} name=${fieldLabel} .index=${i} .property=${property}></sv-property-number>`);
+        if(property.type === "number"){
+            if (property.schema.semantic === "color") {
+                return html`<sv-property-color ?aria-disabled=${disabled} name=${label} .property=${property}></sv-property-color>`;
+            } else if (property.isArray()) {
+                let fields = [];
+                for (let i = 0; i < property.elementCount; ++i) {
+                    
+                    let index_disabled = disabled || this.property.hasInLinks(i);
+                    const fieldLabel = property.schema.labels?.[i] ?? _defaultLabels[i];
+                    fields.push(html`<sv-property-number aria-disabled=${index_disabled} name=${fieldLabel} .index=${i} .property=${property}></sv-property-number>`);
+                }
+                const headerElement = label ? html`<div class="sv-property-name">${label}</div>` : null;
+                return html`${headerElement}<div class="sv-property-group">${fields}</div>`;
+            } else if (schema.percent){
+                return html`<sv-property-percent aria-disabled=${disabled} name=${label} .property=${property}></sv-property-percent>`
+            } else {
+                return html`<sv-property-number aria-disabled=${disabled} name=${label} .property=${property}></sv-property-number>`
             }
-            const headerElement = label ? html`<div class="sv-property-name">${label}</div>` : null;
-            return html`${headerElement}<div class="sv-property-group">${fields}</div>`;
         }else if (schema.event) {
             return html`<sv-property-event aria-disabled=${disabled} name=${label} .property=${property}></sv-property-event>`;
         }else if (schema.options) {
@@ -98,12 +104,6 @@ export default class PropertyView extends CustomElement
             return html`<sv-property-boolean aria-disabled=${disabled} name=${label} .property=${property}></sv-property-boolean>`;
         }else if(property.type === "string"){
             return html`<sv-property-string aria-disabled=${disabled} name=${label} .property=${property}></sv-property-string>`
-        }else if(property.type === "number"){
-            if(schema.percent){
-                return html`<sv-property-percent aria-disabled=${disabled} name=${label} .property=${property}></sv-property-percent>`
-            }else{
-                return html`<sv-property-number aria-disabled=${disabled} name=${label} .property=${property}></sv-property-number>`
-            }
         }else{
             console.warn("Unhandled property :", property.name);
             return html`<div class="sv-property-name">${label}</div><div class="sv-property-group">${property.value} (not editable)</div>`;


### PR DESCRIPTION
## Motivation

As noticed in https://github.com/Smithsonian/dpo-voyager/pull/391#issuecomment-3564253974, numeric input fields use `type="text"` to facilitate displaying percentages. However, this prevents the use of standard browser input methods for regular numbers, which poses problems for accessibility and on mobiles.

#391 adds an input field for date and time which makes the use of `type="text"` particularly inaccessible.

Therefore, this PR extracts the logic for distinguishing between regular numbers and percentages from `PropertyNumber` to `PropertyPercent.ts`.

## Changes

- Create new `PropertyPercentage.ts` type, implementing the custom element `sv-property-percent`
- Remove the conditionals for `schema.percent` from `PropertyNumber`, and use `type="number"` for input fields.
- Add a style for `sv-property-percent` (extending `sv-property-number`)
- Define the step size for numeric component properties to be used by the browser input methods

<img width="444" height="540" alt="image" src="https://github.com/user-attachments/assets/65a18720-90cd-46ca-8b3b-64a29eba7a93" />

Numeric input fields now correctly use `type="number"`, automatically enabling the appropriate input methods in the browser. The percentage input fields are unchanged.