### PR TITLE
Add Datetime (de-)serialization to Snapshots

### DIFF
--- a/libs/ff-graph/source/components/CTweenMachine.ts
+++ b/libs/ff-graph/source/components/CTweenMachine.ts
@@ -17,6 +17,7 @@
 
 import { Dictionary } from "@ff/core/types";
 import { getEasingFunction, EEasingCurve } from "@ff/core/easing";
+import { DateTime } from "luxon";
 
 import Component, { types } from "../Component";
 import Property, { IPropertyDisposeEvent } from "../Property";
@@ -246,7 +247,8 @@ export default class CTweenMachine extends Component
 
     addTargetProperty(property: Property)
     {
-        if (property.type === "object" || property.schema.event) {
+        const isSerializable = (property.type !== "object" && !property.schema.event) || property.schema.semantic === "datetime";
+        if (!isSerializable) {
             throw new Error("can't add object or event properties");
         }
 
@@ -424,7 +426,11 @@ export default class CTweenMachine extends Component
                 }
             }
             else if (!valuesB || doSwitch) {
-                const value = valuesB && valuesB[i] !== null ? valuesB[i] : valuesA[i];
+                let value = valuesB && valuesB[i] !== null ? valuesB[i] : valuesA[i];
+
+                if (property.schema.semantic === "datetime" && typeof value === "string") {
+                    value = DateTime.fromISO(value);
+                }
 
                 if (target.isArray) {
                     let changed = false;

--- a/libs/ff-graph/source/components/CTweenMachine.ts
+++ b/libs/ff-graph/source/components/CTweenMachine.ts
@@ -17,7 +17,6 @@
 
 import { Dictionary } from "@ff/core/types";
 import { getEasingFunction, EEasingCurve } from "@ff/core/easing";
-import { DateTime } from "luxon";
 
 import Component, { types } from "../Component";
 import Property, { IPropertyDisposeEvent } from "../Property";
@@ -429,7 +428,7 @@ export default class CTweenMachine extends Component
                 let value = valuesB && valuesB[i] !== null ? valuesB[i] : valuesA[i];
 
                 if (property.schema.semantic === "datetime" && typeof value === "string") {
-                    value = DateTime.fromISO(value);
+                    value = new Date(value);                    
                 }
 
                 if (target.isArray) {

--- a/source/client/components/CVSnapshots.ts
+++ b/source/client/components/CVSnapshots.ts
@@ -125,8 +125,8 @@ export default class CVSnapshots extends CTweenMachine
         }
 
         snapshotProperties.forEach(property => {
-            const schema = property.schema;
-            if (!schema.event && property.type !== "object") {
+            const isSerializable = (property.type !== "object" && !property.schema.event) || property.schema.semantic === "datetime";
+            if (isSerializable) {
                 const isIncluded = this.hasTargetProperty(property);
                 if (include && !isIncluded) {
                     this.addTargetProperty(property);


### PR DESCRIPTION
In order to use sunlight from #391 in tours, its DateTime property needs to be (de-)serializable.

- Serialization: in `CTweenMachine.addTargetProperty()` and `CVSnapshot.updateComponentTarget()`: introduce `isSerializable` checks that allow for serializing objects if `property.schema.semantic === "datetime"`
- Deserialization: in `CTweenMachine.setValues()`, add a check for `property.schema.semantic === "datetime"` and convert string into a `DateTime` object.
