### PR TITLE
Fix: do not return reject() when users cancels light creation.

### DIFF
--- a/source/client/ui/story/CreateLightMenu.ts
+++ b/source/client/ui/story/CreateLightMenu.ts
@@ -19,7 +19,7 @@ export default class CreateLightMenu extends Popup {
 
         return new Promise((resolve, reject) => {
             menu.on("confirm", () => resolve([menu.lightType, menu.name]));
-            menu.on("close", () => reject());
+            menu.on("close", () => {});
         });
     }
 


### PR DESCRIPTION
The Light creation box returned a `reject()`, triggering the `catch()` method which implied an error.
The change makes it return nothing instead.

Closes https://github.com/Smithsonian/dpo-voyager/issues/413

