### PR TITLE
Translate  "Read more ..." in extented/circle annotations

### DIFF
--- a/source/client/annotations/AnnotationSprite.ts
+++ b/source/client/annotations/AnnotationSprite.ts
@@ -75,6 +75,7 @@ export default class AnnotationSprite extends HTMLSprite<IAnnotationEventMap>
     isAnimating = false;
     assetManager = null;
     audioManager = null;
+    readMoreText = "";
 
     /**
      * Returns the type name of this annotation object.

--- a/source/client/annotations/CircleSprite.ts
+++ b/source/client/annotations/CircleSprite.ts
@@ -262,7 +262,7 @@ class CircleAnnotation extends AnnotationElement
             ${annotationData.imageUri && !isTruncated ? html`<div><img alt="${annotation.imageAltText}" src="${this.sprite.assetManager.getAssetUrl(annotationData.imageUri)}">${annotation.imageCredit ? html`<div class="sv-img-credit">${annotation.imageCredit}</div>` : null}</div>` : null}
             ${!isTruncated ? html`<div class="sv-content"><p>${unsafeHTML(annotation.lead)}</p></div>` : null}
             ${annotationData.audioId && !this.isOverlayed ? html`<div id="audio_container" @pointerdown=${this.onClickAudio}></div>` : null}
-            ${annotationData.articleId && !isTruncated ? html`<ff-button inline id="read-more" text="Read more..." icon="document" @keydown=${this.onKeyDownArticle} @pointerdown=${this.onClickArticle}></ff-button>` : null}
+            ${annotationData.articleId && !isTruncated ? html`<ff-button inline id="read-more" text="${this.sprite.readMoreText}" icon="document" @keydown=${this.onKeyDownArticle} @pointerdown=${this.onClickArticle}></ff-button>` : null}
             ${isTruncated ? html`<ff-button inline id="more-info" text="+more info" @pointerdown=${this.onClickOverlay}></ff-button>` : null}`;  
 
         render(contentTemplate, this.contentElement);

--- a/source/client/annotations/ExtendedSprite.ts
+++ b/source/client/annotations/ExtendedSprite.ts
@@ -231,7 +231,7 @@ class ExtendedAnnotation extends AnnotationElement
         ${annotation.imageUri && !isTruncated ? html`<div><img alt="${annotationObj.imageAltText}" src="${this.sprite.assetManager.getAssetUrl(annotation.imageUri)}">${annotationObj.imageCredit ? html`<div class="sv-img-credit">${annotationObj.imageCredit}</div>` : null}</div>` : null}
         ${!isTruncated ? html`<p>${unsafeHTML(annotationObj.lead)}</p>` : null}
         ${annotation.audioId && !this.overlayed ? html`<div id="audio_container" @pointerdown=${this.onClickAudio}></div>` : null}
-        ${annotation.articleId && !isTruncated ? html`<ff-button inline id="read-more" text="Read more..." icon="document" @keydown=${this.onKeyDownArticle} @pointerdown=${this.onClickArticle}></ff-button>` : null}
+        ${annotation.articleId && !isTruncated ? html`<ff-button inline id="read-more" text="${this.sprite.readMoreText}" icon="document" @keydown=${this.onKeyDownArticle} @pointerdown=${this.onClickArticle}></ff-button>` : null}
         ${isTruncated ? html`<ff-button inline id="more-info" text="+more info" @pointerdown=${this.onClickOverlay} ></ff-button>` : null}`;    
 
         render(contentTemplate, this.contentElement);

--- a/source/client/components/CVAnnotationView.ts
+++ b/source/client/components/CVAnnotationView.ts
@@ -554,6 +554,7 @@ export default class CVAnnotationView extends CObject3D
 
         sprite.assetManager = this.assetManager;
         sprite.audioManager = this.audio;
+        sprite.readMoreText = this.language.getLocalizedString("Read more...");
 
         this._sprites[annotation.id] = sprite;
         this.object3D.add(sprite);
@@ -600,10 +601,12 @@ export default class CVAnnotationView extends CObject3D
         ins.activeTags.set();
 
         // update sprites
+        let readMoreText = language.getLocalizedString("Read more...");
         for (const key in this._annotations) {
             const annotation = this._annotations[key];
             const sprite = this._sprites[annotation.id];
             if (sprite) {
+                sprite.readMoreText = readMoreText;
                 sprite.update();
             }
         }


### PR DESCRIPTION
The "Read more ..."  text that opens linked articles for extended and circle annotations was not translated.   
<img width="212" height="73" alt="image" src="https://github.com/user-attachments/assets/44f14e25-fd94-4982-adbb-923b8040a63a" />

The translations for "Read more..." already exist in the translation files for the 9 languages supported by voyager but were not used.