### PR TITLE
Translate the "+more info" annotation string

### DIFF
--- a/assets/language/string.resources.fr.json
+++ b/assets/language/string.resources.fr.json
@@ -55,6 +55,7 @@
   "Material": "Texture",
   "Measure": "Mesure",
   "Measured Distance": "Distance mesurée",
+  "+more info": "+plus d'info",
   "Move": "Déplacer",
   "Move Article Up": "Déplacer l'article vers le haut",
   "Move Article Down": "Déplacer l'article visite vers le bas",

--- a/source/client/annotations/AnnotationSprite.ts
+++ b/source/client/annotations/AnnotationSprite.ts
@@ -75,6 +75,7 @@ export default class AnnotationSprite extends HTMLSprite<IAnnotationEventMap>
     isAnimating = false;
     assetManager = null;
     audioManager = null;
+    moreInfoText="";
 
     /**
      * Returns the type name of this annotation object.

--- a/source/client/annotations/CircleSprite.ts
+++ b/source/client/annotations/CircleSprite.ts
@@ -263,7 +263,7 @@ class CircleAnnotation extends AnnotationElement
             ${!isTruncated ? html`<div class="sv-content"><p>${unsafeHTML(annotation.lead)}</p></div>` : null}
             ${annotationData.audioId && !this.isOverlayed ? html`<div id="audio_container" @pointerdown=${this.onClickAudio}></div>` : null}
             ${annotationData.articleId && !isTruncated ? html`<ff-button inline id="read-more" text="Read more..." icon="document" @keydown=${this.onKeyDownArticle} @pointerdown=${this.onClickArticle}></ff-button>` : null}
-            ${isTruncated ? html`<ff-button inline id="more-info" text="+more info" @pointerdown=${this.onClickOverlay}></ff-button>` : null}`;  
+            ${isTruncated ? html`<ff-button inline id="more-info" text="${this.sprite.moreInfoText}" @pointerdown=${this.onClickOverlay}></ff-button>` : null}`;  
 
         render(contentTemplate, this.contentElement);
 

--- a/source/client/annotations/ExtendedSprite.ts
+++ b/source/client/annotations/ExtendedSprite.ts
@@ -232,7 +232,7 @@ class ExtendedAnnotation extends AnnotationElement
         ${!isTruncated ? html`<p>${unsafeHTML(annotationObj.lead)}</p>` : null}
         ${annotation.audioId && !this.overlayed ? html`<div id="audio_container" @pointerdown=${this.onClickAudio}></div>` : null}
         ${annotation.articleId && !isTruncated ? html`<ff-button inline id="read-more" text="Read more..." icon="document" @keydown=${this.onKeyDownArticle} @pointerdown=${this.onClickArticle}></ff-button>` : null}
-        ${isTruncated ? html`<ff-button inline id="more-info" text="+more info" @pointerdown=${this.onClickOverlay} ></ff-button>` : null}`;    
+        ${isTruncated ? html`<ff-button inline id="more-info" text="${this.sprite.moreInfoText}" @pointerdown=${this.onClickOverlay} ></ff-button>` : null}`;    
 
         render(contentTemplate, this.contentElement);
 

--- a/source/client/components/CVAnnotationView.ts
+++ b/source/client/components/CVAnnotationView.ts
@@ -554,6 +554,7 @@ export default class CVAnnotationView extends CObject3D
 
         sprite.assetManager = this.assetManager;
         sprite.audioManager = this.audio;
+        sprite.moreInfoText = this.language.getLocalizedString("+more info");
 
         this._sprites[annotation.id] = sprite;
         this.object3D.add(sprite);
@@ -600,10 +601,12 @@ export default class CVAnnotationView extends CObject3D
         ins.activeTags.set();
 
         // update sprites
+        let moreInfoText = language.getLocalizedString("+more info");
         for (const key in this._annotations) {
             const annotation = this._annotations[key];
             const sprite = this._sprites[annotation.id];
             if (sprite) {
+                sprite.moreInfoText = moreInfoText;
                 sprite.update();
             }
         }


### PR DESCRIPTION
Very similar to #420 except the translation does not exist in the other languages yet. I translated it in French.
The "+ more info" string appears when "pushing" an extended annotation against the side of the screen.
However I could not get the circle annotation to display this string :
The "+more info" is in its code,  but when pushed against the side of the screen, the annotation flips toward the center instead of shrinking an displaying "+more info".
Maybe both types of annotation should have the same behavior ?