### PR TITLE
Crash when uploading images to articles if articles folder not yet in asset tree

### DIFF
--- a/source/client/components/CVMediaManager.ts
+++ b/source/client/components/CVMediaManager.ts
@@ -96,10 +96,10 @@ export default class CVMediaManager extends CAssetManager
         return this.assetManager.getAssetUrl(resolvePathname(uri, this.rootUrl));
     }
 
-    uploadFile(name: string, blob: Blob, folder: IAssetEntry): Promise<any>
+    uploadFile(name: string, blob: Blob, folder?: IAssetEntry): Promise<any>
     {
         const filename = decodeURI(name);
-        const filepath = folder.info.path.length > 1 ? folder.info.path + filename : filename;
+        const filepath = folder?.info?.path?.length > 1 ? folder.info.path + filename : filename;
         const url = resolvePathname(filepath, this.rootUrl);
         
         if(this.standaloneFileManager) {

--- a/source/client/ui/story/ArticleEditor.ts
+++ b/source/client/ui/story/ArticleEditor.ts
@@ -241,8 +241,9 @@ export default class ArticleEditor extends SystemView
 
             images_upload_handler: (file, progress) => new Promise((resolve, reject) => {
                 const filename = this.mediaManager.getUniqueName(CVMediaManager.articleFolder + "/" + file.filename());
-                this.mediaManager.uploadFile(filename, file.blob(), this.mediaManager.getAssetByPath(CVMediaManager.articleFolder + "/")).
-                    then( () => { resolve(this.assetManager.getAssetUrl(CVMediaManager.articleFolder + "/" + filename))});
+                const fullPath = CVMediaManager.articleFolder + "/" + filename;
+                this.mediaManager.uploadFile(fullPath, file.blob()).
+                    then( () => { resolve(this.assetManager.getAssetUrl(fullPath))});
             }),
 
             init_instance_callback: (editor) => {
@@ -251,8 +252,9 @@ export default class ArticleEditor extends SystemView
                     if(blobInfo) {
                         if(this.standaloneFileManager) {
                             const filename = this.mediaManager.getUniqueName(CVMediaManager.articleFolder + "/" + blobInfo.filename());
-                            this.mediaManager.uploadFile(filename, blobInfo.blob(), this.mediaManager.getAssetByPath(CVMediaManager.articleFolder + "/"))
-                            img.src = this.assetManager.getAssetUrl(CVMediaManager.articleFolder + "/" + filename);
+                            const fullPath = CVMediaManager.articleFolder + "/" + filename;
+                            this.mediaManager.uploadFile(fullPath, blobInfo.blob())
+                            img.src = this.assetManager.getAssetUrl(fullPath);
                         }
                         else {
                             return true;


### PR DESCRIPTION
  ## Problem

   When inserting an image into an article via the TinyMCE editor, `uploadFile` receives `undefined` as the `folder` argument and crashes:

   ```
   Uncaught TypeError: Cannot read properties of undefined (reading 'info')
       at CVMediaManager.uploadFile
   ```

   **Root cause:** `getAssetByPath("articles/")` looks up the folder entry in `_assetsByPath`, which is populated asynchronously during `refresh()`. If the asset tree has not finished loading when the upload is triggered, the lookup returns `undefined` even though the `articles/` folder exists on the
   server.