### PR TITLE
Add preliminary Kintsugi support for Voyager

### DIFF
--- a/source/client/io/ModelReader.ts
+++ b/source/client/io/ModelReader.ts
@@ -107,6 +107,38 @@ export default class ModelReader
         return this.loadModel(url, {signal})
         .then(data=>this.gltfLoader.parseAsync(data, resourcePath))
         .then(gltf=> {
+            // Check for Kintsugi materials and extract them automatically from the glTF
+            gltf.scene.traverse(object => {
+                const material = object["material"] as MeshStandardMaterial
+
+                if (material) {
+                    // Use Kintsugi diffuse instead of the albedo map (which incorporates both diffuse and specular)
+                    var kintsugiDiffuse = material.userData["diffuseTexture"]
+                    if (kintsugiDiffuse) {
+                        var kintsugiDiffuseTex = gltf.parser.loadTexture(kintsugiDiffuse.index)
+                        .then(texture => {
+                            texture.colorSpace = SRGBColorSpace;
+                            material.map = texture
+                            material.needsUpdate = true
+                        })
+                    }
+
+                    // Kintsugi specular is loaded as a custom texture map
+                    var kintsugiSpecular = material.userData["specularTexture"]
+                    if (kintsugiSpecular) {
+                        var kintsugiSpecularTex = gltf.parser.loadTexture(kintsugiSpecular.index)
+                        .then(texture => {
+                            texture.colorSpace = SRGBColorSpace;
+                            material.metalness = 0.0
+                            material.roughness = 1.0
+                            material.userData.shader.uniforms["specularOverrideMap"].value = texture
+                            material.defines["USE_KINTSUGI"] = true
+                            material.defines["USE_SPECULAR"] = true
+                            material.needsUpdate = true
+                        })
+                    }
+                }
+            })
             if(gltf.userData.gltfExtensions) {
                 const variantsExtension = gltf.userData.gltfExtensions[ 'KHR_materials_variants' ];
                 if(variantsExtension) {

--- a/source/client/shaders/ShaderExtension.ts
+++ b/source/client/shaders/ShaderExtension.ts
@@ -83,12 +83,55 @@ export function injectFragmentShaderCode(shader: string) {
     )
 
     // Kintsugi specific shader modifications
+    // - Only use single scattering since Kintsugi is optimized against a single scattering model.
+    // - Simplfy by assuming no iridescence, sheen etc. which Kintsugi does not support.
+    // - Omit energy conservation from indirect lighting for conistency with both three.js direct lighting as well as Kintsugi's optimization process.
+    shader = shader.replace(
+        '#include <lights_physical_pars_fragment>',
+        '#include <lights_physical_pars_fragment> \n \
+        \n \
+        #ifdef USE_KINTSUGI \n \
+            void RE_Direct_Kintsugi( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n \
+            \n \
+                float dotNL = saturate( dot( geometryNormal, directLight.direction ) ); \n \
+                vec3 irradiance = dotNL * directLight.color; \n \
+                reflectedLight.directSpecular += irradiance * BRDF_GGX( directLight.direction, geometryViewDir, geometryNormal, material ); \n \
+	            reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseContribution ); \n \
+            } \n \
+            \n \
+            void RE_IndirectSpecular_Kintsugi( const in vec3 radiance, const in vec3 irradiance, const in vec3 clearcoatRadiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in PhysicalMaterial material, inout ReflectedLight reflectedLight) { \n \
+            \n \
+                vec3 singleScattering = vec3( 0.0 ); \n \
+                vec3 multiScattering = vec3( 0.0 ); \n \
+                computeMultiscattering( geometryNormal, geometryViewDir, material.specularColor, material.specularF90, material.roughness, singleScattering, multiScattering ); \n \
+                \n \
+                vec3 diffuse = material.diffuseContribution; \n \
+                vec3 cosineWeightedIrradiance = irradiance * RECIPROCAL_PI; \n \
+                \n \
+                vec3 indirectSpecular = radiance * singleScattering; \n \
+                vec3 indirectDiffuse = diffuse * cosineWeightedIrradiance; \n \
+                \n \
+                reflectedLight.indirectSpecular += indirectSpecular; \n \
+                reflectedLight.indirectDiffuse += indirectDiffuse; \n \
+            } \n \
+            #undef RE_Direct \n \
+            #undef RE_IndirectSpecular \n \
+            #define RE_Direct           RE_Direct_Kintsugi \n \
+            #define RE_IndirectSpecular RE_IndirectSpecular_Kintsugi \n \
+        #endif\n \
+        \n'
+    )
+
+    // - Omit any adjustments to roughness to match Kintsugi's optimization process
+    // - Override the specular color (not using metallicity workflow)
+    // - specularColorBlended appears to be what is actually used by built-in BRDF functions
     shader = shader.replace(
         '#include <lights_physical_fragment>',
         '#include <lights_physical_fragment>\n \
         \n \
         #ifdef USE_KINTSUGI\n \
-            material.specularColor = texture2D(specularOverrideMap, vMapUv).rgb;\n \
+            material.roughness = clamp( roughnessFactor, 0.0525, 1.0 );\n \
+            material.specularColor = material.specularColorBlended = texture2D(specularOverrideMap, vMapUv).rgb;\n \
         #endif\n \
         \n'
     )


### PR DESCRIPTION
- Modified ModelReader to automatically detect and load Kintsugi textures referenced in the glTF userData -- no longer necessary to specify them manually.
-  Modified ShaderExtension with the required shader code injections for Kintsugi models to appear correctly.  A custom implementation of RE_Direct and RE_IndirectSpecular have been provided that strip out much of the physically-based rendering in order to match Kintsugi's optimization model.  The specular color is also now correctly overridden even for functions that use specularColorBlended.