### PR TITLE
Handle missing component in updateComponentTarget

### DIFF
--- a/source/client/components/CVSnapshots.ts
+++ b/source/client/components/CVSnapshots.ts
@@ -137,7 +137,7 @@ export default class CVSnapshots extends CTweenMachine
 
     protected updateComponentTarget(component: Component, include: boolean)
     {
-        const snapshotProperties = component["snapshotProperties"] as Property[];
+        const snapshotProperties = component?.["snapshotProperties"] as Property[];
         if (!snapshotProperties) {
             return;
         }


### PR DESCRIPTION
A component (or a model/light's transform) may already be gone when this runs during node teardown on a document swap.

Saw it in the wild on `light.transform` being undefined (relies on a "no-throw" `components.get(CTransform, true)`).

Due to the many call sites of this methods, I took the route of guarding against a null component in the method instead of guarding all call sites where this could happen. Another fix would be to ensure a transform is not torn down before its attached object, but that is a much larger change, I'm not so sure that'd be desirable?

I kept the signature, since calling `CVSnapshot.updateComponentTarget()` with a null component is definitely not intended behavior.