### PR TITLE
Add support for multiple models using the same animation name

### DIFF
--- a/source/client/components/CVActionManager.ts
+++ b/source/client/components/CVActionManager.ts
@@ -239,7 +239,7 @@ export default class CVActionManager extends Component
         model.object3D.traverse(object => {
             if (object.animations.length > 0) {
                 object.animations.forEach((anim) => {
-                    this._animMap[anim.name] = object;
+                    this._animMap[model.node.id + anim.name] = object;
                 })
             }
         });
@@ -388,7 +388,7 @@ export default class CVActionManager extends Component
 
     protected playAnimation(component: CVModel2, action: IAction) 
     {
-        const mesh = this._animMap[action.animation];
+        const mesh = this._animMap[component.node.id + action.animation];
 
         if(!mesh) {
             console.warn("No playable animation found!");

--- a/source/client/components/CVActionsTask.ts
+++ b/source/client/components/CVActionsTask.ts
@@ -342,7 +342,8 @@ export default class CVActionsTask extends CVTask
         this._actionIds.length = 0;
         this._actionIds.push("0");
         this.getSystemComponents(CVMeta).forEach((meta) => {
-            actionOptions.push(...meta.actions.items.map(action => action.name));
+            const model = meta.node.getComponent(CVModel2, true);
+            actionOptions.push(...meta.actions.items.map(action => model.node.name + " : " + action.name));
             this._actionIds.push(...meta.actions.items.map(action => action.id));
         });
         this.ins.action.setOptions(actionOptions);


### PR DESCRIPTION
The _animMap dictionary in CVActionManager currently uses only the name of the animation as its key. 
Using the string `model.id + animation.name` instead allow to support multiple models using the same animation name. 

To facilitate picking between similar actions on the different models, this pull request also displays the model name in front of the action name in the dropdown for "OnActionEnd" and "OnActionBegin" triggers. 