### PR TITLE
Conditional save: fine-grained handling of HTTP status codes

### DIFF
--- a/source/client/components/CVAssetWriter.ts
+++ b/source/client/components/CVAssetWriter.ts
@@ -23,8 +23,23 @@ import CVDocument from "./CVDocument";
 import CVAssetManager from "./CVAssetManager";
 import CVStandaloneFileManager from "./CVStandaloneFileManager"
 
+import { assetRevisions } from "../io/AssetRevisions";
+
 
 ////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Thrown when a server refuses a conditional write because the asset changed since we read it —
+ * `409 Conflict` or `412 Precondition Failed`. Nothing was written.
+ */
+export class WriteConflictError extends Error
+{
+    constructor(readonly response: Response, message: string)
+    {
+        super(message);
+        this.name = "WriteConflictError";
+    }
+}
 
 export default class CVAssetWriter extends Component
 {
@@ -53,31 +68,58 @@ export default class CVAssetWriter extends Component
     }
 
 
-    async put(body: string|BlobPart, contentType :string, assetPath: string): Promise<void>
+    /**
+     * Writes an asset and returns the response.
+     * @throws {WriteConflictError} if the server refused a conditional write.
+     */
+    async put(body: string|BlobPart, contentType :string, assetPath: string): Promise<Response>
     {
 
         const standaloneManager = this.standaloneFileManager;
         if(standaloneManager) {
             standaloneManager.addFile(assetPath, [body]);
-            return Promise.resolve();
+            return new Response(null, { status: 204 });
         }
 
         const url = this.assetManager.getAssetUrl(assetPath);
+        const headers :Record<string, string> = {
+            "Accept": "text/plain",
+            "Content-Type": contentType,
+        };
+
+        const etag = assetRevisions.get(url);
+        if (etag) {
+            headers["If-Match"] = etag;
+        }
+
         const res = await fetch(url, {
             method: "PUT",
-            headers:{
-                "Accept": "text/plain",
-                "Content-Type": contentType,
-            },
+            headers,
             body,
         });
+
+        // WebDAV answers 409 to an unconditional PUT with a missing parent collection, which is
+        // a different problem: only a conditional write can be refused for being out of date.
+        if (etag && (res.status === 409 || res.status === 412)) {
+            throw new WriteConflictError(res,
+                `'${assetPath}' was modified since it was read, and nothing was written`);
+        }
+
         if(!res.ok) {
             const txt = await res.text();
             throw new Error(`Failed to PUT ${contentType} to ${url}: ${txt ?? res.statusText}`);
         }
+
+        // On 205 the entity-tag names content we do not have, so it must not be adopted here:
+        // the caller either reloads, picking up the new tag with it, or keeps the one we hold.
+        if (res.status !== 205) {
+            assetRevisions.update(url, res);
+        }
+
+        return res;
     }
 
-    async putJSON(json: any, assetPath: string): Promise<void>
+    async putJSON(json: any, assetPath: string): Promise<Response>
     {
         if (typeof json !== "string") {
             json = JSON.stringify(json);
@@ -85,16 +127,22 @@ export default class CVAssetWriter extends Component
         return await this.put(json, "application/json", assetPath);
     }
 
-    async putText(text: string, assetPath: string): Promise<void>
+    async putText(text: string, assetPath: string): Promise<Response>
     {
         return await this.put(text, "text/plain", assetPath);
     }
 
-    putDocument(document: CVDocument, components?: INodeComponents, assetPath?: string): Promise<void>
+    putDocument(document: CVDocument, components?: INodeComponents, assetPath?: string): Promise<Response>
     {
         const documentData = document.deflateDocument(components);
 
         return this.putJSON(documentData, assetPath || document.outs.assetPath.value);
+    }
+
+    /** Forgets which revision of an asset we hold, so that the next write to it is unconditional. */
+    forgetRevision(assetPath: string)
+    {
+        assetRevisions.forget(this.assetManager.getAssetUrl(assetPath));
     }
 
 }

--- a/source/client/components/CVLanguageManager.ts
+++ b/source/client/components/CVLanguageManager.ts
@@ -24,6 +24,30 @@ import { enumToArray } from "@ff/core/types";
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ * A string to display, with what is needed to translate it.
+ *
+ * Short text is its own dictionary key. Anything long enough that editing a word would invalidate
+ * every translation of it, or that reads badly as a key, gets an explicit `key` instead and keeps
+ * `text` as what to show while no translation exists. `args` fill the `{0}`, `{1}`, ...
+ * placeholders after the lookup, so a message that names a file stays a single key.
+ */
+export interface ILocalizedString {
+    /** Text to display where the dictionary has no entry. */
+    text: string;
+    /** Dictionary key. Defaults to `text`. */
+    key?: string;
+    /** Values for the `{0}`, `{1}`, ... placeholders. */
+    args?: (string | number)[];
+}
+
+/** Substitutes `{0}`, `{1}`, ... in `text` with `args`. Unmatched placeholders are left alone. */
+function format(text: string, args: (string | number)[]): string
+{
+    return text.replace(/\{(\d+)\}/g, (placeholder, index) =>
+        args[index] !== undefined ? String(args[index]) : placeholder);
+}
+
 export interface ITranslation {
     [key: string]: string;
 }
@@ -166,9 +190,17 @@ export default class CVLanguageManager extends Component
         return  this.getLocalizedStringIn (text, this._activeSeneLanguageTranslations, ELanguageType[this.outs.activeLanguage.value]);
     }
 
-    getUILocalizedString(text: string): string
+    getUILocalizedString(text: string | ILocalizedString): string
     {   
-        return this.getLocalizedStringIn(text, this._uiLanguageTranslations, ELanguageType[this.outs.uiLanguage.value]);
+        const string :ILocalizedString = typeof text === "string" ? { text } : text;
+        const key = string.key ?? string.text;
+
+        const localized = this.getLocalizedStringIn(key, this._uiLanguageTranslations, ELanguageType[this.outs.uiLanguage.value]);
+        // getLocalizedStringIn() echoes the key back when the dictionary has no entry for it.
+        // An explicit key is an identifier, not display text, so `text` is what to show instead.
+        const result = localized === key ? string.text : localized;
+
+        return string.args ? format(result, string.args) : result;
     }
 
     getSceneSetupLocalizedString(text: string): string

--- a/source/client/components/CVStoryApplication.ts
+++ b/source/client/components/CVStoryApplication.ts
@@ -21,15 +21,18 @@ import { downloadZip } from "client-zip";
 import Component, { Node, types } from "@ff/graph/Component";
 
 import Notification from "@ff/ui/Notification";
+import MessageBox from "@ff/ui/MessageBox";
 
 import CVAssetManager from "./CVAssetManager";
-import CVAssetWriter from "./CVAssetWriter";
+import CVAssetReader from "./CVAssetReader";
+import CVAssetWriter, { WriteConflictError } from "./CVAssetWriter";
 import CVTaskProvider from "./CVTaskProvider";
 import CVDocumentProvider from "./CVDocumentProvider";
-import { INodeComponents } from "./CVDocument";
+import CVDocument, { INodeComponents } from "./CVDocument";
 
 import { ETaskMode } from "../applications/taskSets";
 
+import CVLanguageManager from "./CVLanguageManager";
 import CVMediaManager from "./CVMediaManager";
 import CVMeta from "./CVMeta";
 import CVStandaloneFileManager from "./CVStandaloneFileManager";
@@ -62,8 +65,14 @@ export default class CVStoryApplication extends Component
     protected get assetManager() {
         return this.getMainComponent(CVAssetManager);
     }
+    protected get assetReader() {
+        return this.getMainComponent(CVAssetReader);
+    }
     protected get assetWriter() {
         return this.getMainComponent(CVAssetWriter);
+    }
+    protected get language() {
+        return this.system.getComponent(CVLanguageManager);
     }
     protected get mediaManager() {
         return this.system.getMainComponent(CVMediaManager);
@@ -118,8 +127,8 @@ export default class CVStoryApplication extends Component
 
                 if(storyMode !== ETaskMode.Standalone) {
                     this.assetWriter.putJSON(json, cvDocument.assetPath)
-                    .then(() => new Notification(`Successfully uploaded file to '${cvDocument.assetPath}'`, "info", 4000))
-                    .catch(e => new Notification(`Failed to upload file to '${cvDocument.assetPath}'`, "error", 8000));
+                    .then(response => this.onDocumentSaved(response, cvDocument))
+                    .catch(error => this.onDocumentSaveFailed(error, cvDocument, json));
                 }
                 else {
                     // Standalone save
@@ -152,6 +161,81 @@ export default class CVStoryApplication extends Component
 
 
         return false;
+    }
+
+    /**
+     * Reports what the server did with a document we just saved. `205 Reset Content` means what
+     * is stored is our changes combined with somebody else's, so the scene on screen is stale.
+     */
+    protected onDocumentSaved(response: Response, cvDocument: CVDocument): Promise<void>
+    {
+        const assetPath = cvDocument.assetPath;
+
+        if (response.status !== 205) {
+            new Notification(this.language.getUILocalizedString({ text: "Successfully uploaded file to '{0}'", args: [assetPath] }), "info", 4000);
+            return Promise.resolve();
+        }
+
+        return MessageBox.show(this.language.getUILocalizedString("Scene merged"),
+            this.language.getUILocalizedString({
+                key: "save.merged",
+                text: "Somebody else changed '{0}' while you were editing it. Load the merged version now?",
+                args: [assetPath],
+            }),
+            "warning", "yes-no")
+        .then(result => {
+            if (!result.ok) {
+                new Notification(this.language.getUILocalizedString({ text: "Kept your version of '{0}'.", args: [assetPath] }), "warning", 8000);
+                return;
+            }
+
+            return this.reloadDocument(cvDocument)
+            .then(() => { new Notification(this.language.getUILocalizedString({ text: "Loaded the merged version of '{0}'", args: [assetPath] }), "info", 4000); })
+            .catch(() => { new Notification(this.language.getUILocalizedString({ text: "Failed to reload '{0}'", args: [assetPath] }), "error", 8000); });
+        });
+    }
+
+    /**
+     * Reports a save that did not happen. A {@link WriteConflictError} means nothing was stored
+     * and the only copy of the change is the one on screen.
+     */
+    protected onDocumentSaveFailed(error: Error, cvDocument: CVDocument, json: string): Promise<void>
+    {
+        const assetPath = cvDocument.assetPath;
+
+        if (!(error instanceof WriteConflictError)) {
+            new Notification(this.language.getUILocalizedString({ text: "Failed to upload file to '{0}'", args: [assetPath] }), "error", 8000);
+            return Promise.resolve();
+        }
+
+        return MessageBox.show(this.language.getUILocalizedString("Save refused"),
+            this.language.getUILocalizedString({
+                key: "save.refused",
+                text: "Somebody else changed '{0}' since you opened it, so nothing was saved. "
+                    + "Save your version over theirs?",
+                args: [assetPath],
+            }),
+            "warning", "yes-no")
+        .then(result => {
+            if (!result.ok) {
+                new Notification(this.language.getUILocalizedString({ text: "'{0}' was not saved.", args: [assetPath] }), "warning", 8000);
+                return;
+            }
+
+            this.assetWriter.forgetRevision(assetPath);
+            return this.assetWriter.putJSON(json, assetPath)
+            .then(response => this.onDocumentSaved(response, cvDocument))
+            .catch(() => { new Notification(this.language.getUILocalizedString({ text: "Failed to upload file to '{0}'", args: [assetPath] }), "error", 8000); });
+        });
+    }
+
+    /** Replaces the active document with the one on the server, rebuilding the whole node tree. */
+    protected reloadDocument(cvDocument: CVDocument): Promise<CVDocument>
+    {
+        const assetPath = cvDocument.assetPath;
+
+        return this.assetReader.getJSON(assetPath)
+        .then(data => this.documentProvider.amendDocument(data, assetPath, false));
     }
 
     /**

--- a/source/client/io/AssetRevisions.ts
+++ b/source/client/io/AssetRevisions.ts
@@ -1,0 +1,56 @@
+/**
+ * 3D Foundation Project
+ * Copyright 2025 Smithsonian Institution
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Remembers which revision of an asset this session last saw, as the entity-tag the server
+ * gave for it, so a write can quote it back in `If-Match`.
+ */
+export class AssetRevisions
+{
+    private _tags: Record<string, string> = {};
+
+    /** Records the revision a response reports for `url`, clearing it if there is none. */
+    update(url: string, response: Response)
+    {
+        const etag = response.headers.get("ETag");
+
+        // Only a strong validator may be used with If-Match (RFC 9110 §13.1.1).
+        if (etag && !etag.startsWith("W/")) {
+            this._tags[url] = etag;
+        }
+        else {
+            delete this._tags[url];
+        }
+    }
+
+    /** The revision `url` was last seen at, or undefined if we can't say. */
+    get(url: string): string | undefined
+    {
+        return this._tags[url];
+    }
+
+    /** Forgets `url`, so that the next write to it is unconditional. */
+    forget(url: string)
+    {
+        delete this._tags[url];
+    }
+}
+
+/** The store shared by every reader and writer in the page, keyed by absolute URL. */
+export const assetRevisions = new AssetRevisions();

--- a/source/client/io/FileReader.ts
+++ b/source/client/io/FileReader.ts
@@ -17,6 +17,8 @@
 
 import { LoadingManager } from "three";
 
+import { assetRevisions } from "./AssetRevisions";
+
 ////////////////////////////////////////////////////////////////////////////////
 /**
  * Most generic loader, for files that require little to no processing.
@@ -31,24 +33,44 @@ export default class FileReader
         this._loadingManager = loadingManager;
     }
 
+    /**
+     * Fetches a file and hands back the whole response, for callers that need more than the
+     * body. Throws on any status other than 2xx.
+     *
+     * Reading a file is also how we learn which revision of it we hold, so the response's
+     * entity-tag is recorded here for anyone who later writes the same URL back.
+     */
+    async getResponse(url: string, accept: string): Promise<Response>
+    {
+        const result = await fetch(url, {
+            headers: {
+                "Accept": accept
+            }
+        });
+
+        if (!result.ok) {
+            throw new Error(`failed to fetch from '${url}', status: ${result.status} ${result.statusText}`);
+        }
+
+        assetRevisions.update(url, result);
+        return result;
+    }
+
     async getJSON(url: string): Promise<any>
     {
         this._loadingManager.itemStart(url);
 
-        return fetch(url, {
-            headers: {
-                "Accept": "application/json"
-            }
-        }).then(result => {
-            if (!result.ok) {
-                this._loadingManager.itemError(url);
-                this._loadingManager.itemEnd(url);
-                throw new Error(`failed to fetch from '${url}', status: ${result.status} ${result.statusText}`);
-            }
-
+        try {
+            const result = await this.getResponse(url, "application/json");
+            return await result.json();
+        }
+        catch (error) {
+            this._loadingManager.itemError(url);
+            throw error;
+        }
+        finally {
             this._loadingManager.itemEnd(url);
-            return result.json();
-        });
+        }
     }
 
     /**
@@ -56,21 +78,7 @@ export default class FileReader
      */
     async getText(url: string): Promise<any>
     {
-        //this._loadingManager.itemStart(url);
-
-        return fetch(url, {
-            headers: {
-                "Accept": url.endsWith(".html")?"text/html":"text/plain"
-            }
-        }).then(result => {
-            if (!result.ok) {
-                //this._loadingManager.itemError(url);
-                //this._loadingManager.itemEnd(url);
-                throw new Error(`failed to fetch from '${url}', status: ${result.status} ${result.statusText}`);
-            }
-
-            //this._loadingManager.itemEnd(url);
-            return result.text();
-        });
+        const result = await this.getResponse(url, url.endsWith(".html") ? "text/html" : "text/plain");
+        return result.text();
     }
 }

--- a/source/client/nodes/NVNode.ts
+++ b/source/client/nodes/NVNode.ts
@@ -117,11 +117,31 @@ export default class NVNode extends Node
         const childIndices = node.children;
         if (childIndices) {
             childIndices.forEach(childIndex => {
-                const childNode = this.graph.createCustomNode(NVNode);
+                const childNode = this.createChildNode(document, childIndex);
                 this.transform.addChild(childNode.transform);
                 childNode.fromDocument(document, childIndex, pathMap);
             });
         }
+    }
+
+    /**
+     * Creates the node for one entry of the document's node list, keeping the id the document
+     * carries. An id already in use is dropped rather than reused: the node registry throws on
+     * a duplicate, which would fail the whole load.
+     */
+    protected createChildNode(document: IDocument, nodeIndex: number): NVNode
+    {
+        const id = document.nodes[nodeIndex].id;
+
+        if (!id || this.system.nodes.getById(id)) {
+            return this.graph.createCustomNode(NVNode);
+        }
+
+        // createCustomNode() skips createComponents() when given an id, expecting fromJSON() to
+        // restore them. fromDocument() builds its own, but needs the transform to exist first.
+        const node = this.graph.createCustomNode(NVNode, undefined, id);
+        node.createComponents();
+        return node;
     }
 
     toDocument(document: IDocument, pathMap: Map<Component, string>, components?: INodeComponents)
@@ -140,6 +160,8 @@ export default class NVNode extends Node
         document.nodes.push(node);
 
         pathMap.set(this.transform, `node/${nodeIndex}`);
+
+        node.id = this.id;
 
         if (this.name) {
             node.name = this.name;

--- a/source/client/nodes/NVScene.ts
+++ b/source/client/nodes/NVScene.ts
@@ -62,7 +62,7 @@ export default class NVScene extends NVNode
         const nodeIndices = scene.nodes;
         if (nodeIndices) {
             nodeIndices.forEach(nodeIndex => {
-                const childNode = this.graph.createCustomNode(NVNode);
+                const childNode = this.createChildNode(document, nodeIndex);
                 this.transform.addChild(childNode.transform);
                 childNode.fromDocument(document, nodeIndex, pathMap);
             });

--- a/source/client/schema/document.ts
+++ b/source/client/schema/document.ts
@@ -72,6 +72,8 @@ export interface IScene
  */
 export interface INode
 {
+    /** Identifier for this node, stable across a load/save round-trip. */
+    id?: string;
     name?: string;
     children?: Index[];
 

--- a/source/client/schema/json/document.schema.json
+++ b/source/client/schema/json/document.schema.json
@@ -31,6 +31,10 @@
             "$id": "#node",
             "type": "object",
             "properties": {
+                "id": {
+                    "description": "Identifier for this node, stable across load/save round-trips.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/source/client/ui/story/ArticleEditor.ts
+++ b/source/client/ui/story/ArticleEditor.ts
@@ -47,11 +47,12 @@ import SystemView, { customElement } from "@ff/scene/ui/SystemView";
 
 import CVAssetManager from "../../components/CVAssetManager";
 import CVAssetReader from "../../components/CVAssetReader";
-import CVAssetWriter from "../../components/CVAssetWriter";
+import CVAssetWriter, { WriteConflictError } from "../../components/CVAssetWriter";
 
 import CVMediaManager, { IAssetOpenEvent, IAssetRenameEvent } from "../../components/CVMediaManager";
 import CVStandaloneFileManager from "../../components/CVStandaloneFileManager";
 import CVReader from "../../components/CVReader";
+import CVLanguageManager from "../../components/CVLanguageManager";
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -81,6 +82,9 @@ export default class ArticleEditor extends SystemView
     protected get articleReader() {
         return this.system.getComponent(CVReader);
     }
+    protected get language() {
+        return this.system.getComponent(CVLanguageManager);
+    }
 
     openArticle(assetPath: string)
     {
@@ -103,7 +107,8 @@ export default class ArticleEditor extends SystemView
         if (tinymce.activeEditor.isDirty() && this._assetPath) {
             return MessageBox.show("Close Article", "Would you like save your changes?", "warning", "yes-no").then(result => {
                 if (result.ok) {
-                    return this.writeArticle().then(() => this.clearArticle());
+                    // only close over content that made it to the server
+                    return this.writeArticle().then(saved => saved ? this.clearArticle() : undefined);
                 }
                 else {
                     return this.clearArticle();
@@ -156,7 +161,12 @@ export default class ArticleEditor extends SystemView
         return Promise.resolve(content);
     }
 
-    protected writeArticle()
+    /**
+     * Writes the article in the editor back to the server.
+     * @returns whether the article is now stored. Callers must not discard the editor's
+     * content when it is not.
+     */
+    protected writeArticle(): Promise<boolean>
     {
         const basePath = this.assetManager.getAssetBasePath(this._assetPath);
 
@@ -173,15 +183,74 @@ export default class ArticleEditor extends SystemView
             return pre + this.assetManager.getRelativeAssetPath(assetUrl, basePath) + post;
         });
 
-        return this.assetWriter.putText(content, this._assetPath)
-            .then(() => {
-                tinymce.activeEditor.setDirty(false);
-                this.articleReader.ins.articleId.set();
-                new Notification(`Article successfully written to '${this._assetPath}'`, "info");
-            })
-            .catch(error => {
-                new Notification(`Failed to write article to '${this._assetPath}': ${error.message}`, "error");
+        const assetPath = this._assetPath;
+
+        return this.assetWriter.putText(content, assetPath)
+            .then(response => this.onArticleWritten(response, assetPath))
+            .catch(error => this.onArticleWriteFailed(error, content, assetPath));
+    }
+
+    /**
+     * Reports what the server did with an article we just wrote. `205 Reset Content` means what
+     * is stored is our text combined with somebody else's, not the text we sent.
+     */
+    protected onArticleWritten(response: Response, assetPath: string): Promise<boolean>
+    {
+        tinymce.activeEditor.setDirty(false);
+        this.articleReader.ins.articleId.set();
+
+        if (response.status === 205) {
+            return MessageBox.show(this.language.getUILocalizedString("Article merged"),
+                this.language.getUILocalizedString({
+                    key: "article.merged",
+                    text: "Somebody else changed '{0}' while you were editing it. Your text was "
+                        + "saved and combined with theirs, so the article in the editor is not the "
+                        + "one that is stored. Load the merged article now?",
+                    args: [assetPath],
+                }),
+                "warning", "yes-no")
+            .then(result => result.ok ? this.readArticle(assetPath) : undefined)
+            .then(() => true);
+        }
+
+        new Notification(this.language.getUILocalizedString({ text: "Article successfully written to '{0}'", args: [assetPath] }), "info");
+        return Promise.resolve(true);
+    }
+
+    /**
+     * Reports a write that did not happen. On a {@link WriteConflictError} nothing was stored,
+     * so the editor keeps its content either way.
+     */
+    protected onArticleWriteFailed(error: Error, content: string, assetPath: string): Promise<boolean>
+    {
+        if (!(error instanceof WriteConflictError)) {
+            new Notification(this.language.getUILocalizedString({ text: "Failed to write article to '{0}': {1}", args: [assetPath, error.message] }), "error");
+            return Promise.resolve(false);
+        }
+
+        return MessageBox.show(this.language.getUILocalizedString("Save refused"),
+            this.language.getUILocalizedString({
+                key: "article.refused",
+                text: "Somebody else changed '{0}' since you opened it, so nothing was saved. "
+                    + "Save your version over theirs? Choose No to keep editing — your text is "
+                    + "still in the editor.",
+                args: [assetPath],
+            }),
+            "warning", "yes-no")
+        .then(result => {
+            if (!result.ok) {
+                new Notification(this.language.getUILocalizedString({ text: "'{0}' was not saved.", args: [assetPath] }), "warning", 8000);
+                return false;
+            }
+
+            this.assetWriter.forgetRevision(assetPath);
+            return this.assetWriter.putText(content, assetPath)
+            .then(response => this.onArticleWritten(response, assetPath))
+            .catch(retryError => {
+                new Notification(this.language.getUILocalizedString({ text: "Failed to write article to '{0}': {1}", args: [assetPath, retryError.message] }), "error");
+                return false;
             });
+        });
     }
 
     protected clearArticle()

--- a/source/server/index.ts
+++ b/source/server/index.ts
@@ -23,6 +23,8 @@ import * as http from "http";
 import * as https from "https";
 import * as fs from "fs";
 
+import { pipeline } from "stream/promises";
+
 import * as express from "express";
 import * as morgan from "morgan";
 import { v2 as webdav } from "webdav-server";
@@ -77,6 +79,122 @@ app.use("/", express.static(staticDir));
 // documentation server
 app.use("/doc", express.static(docDir));
 
+////////////////////////////////////////////////////////////////////////////////
+// FILE SERVER
+//
+// GET and PUT of the file directory are handled here; the WebDAV server below serves everything
+// else. Both are registered first so they see a request before it does.
+
+/** Resolves a request path inside the file directory, or null if it escapes it. */
+function resolveFilePath(pathname: string): string {
+    let relative: string;
+    try {
+        relative = decodeURIComponent(pathname).replace(/[\\/]+/g, "/");
+    }
+    catch (error) {
+        return null; // malformed percent-encoding
+    }
+
+    if (relative.indexOf("\0") !== -1) {
+        return null;
+    }
+
+    const fullPath = path.join(fileDir, relative);
+    if (fullPath !== fileDir && !fullPath.startsWith(fileDir + path.sep)) {
+        return null;
+    }
+
+    return fullPath;
+}
+
+/**
+ * Strong entity-tag for a file, from its size and modification time — the validator express
+ * computes for static files, minus the `W/` that marks it weak. `If-Match` requires strong
+ * comparison (RFC 9110 13.1.1), so a weak tag would leave every write unconditional.
+ */
+function fileEtag(stats): string {
+    return `"${stats.size.toString(16)}-${stats.mtime.getTime().toString(16)}"`;
+}
+
+async function statOrNull(fullPath: string) {
+    try {
+        return await fs.promises.stat(fullPath);
+    }
+    catch (error) {
+        if (error.code === "ENOENT") {
+            return null;
+        }
+        throw error;
+    }
+}
+
+/**
+ * Conditional PUT, which WebDAV's does not do:
+ *
+ *  - no `If-Match`, or one that matches -- written; `201` if new, `204` if it replaced
+ *    something, carrying the entity-tag of what is now stored
+ *  - an `If-Match` that does not match  -- `412`, and nothing is written
+ */
+async function handlePut(req, res, next) {
+    if (req.method !== "PUT") {
+        return next();
+    }
+
+    const fullPath = resolveFilePath(req.path);
+    if (!fullPath) {
+        return res.sendStatus(400);
+    }
+
+    const stats = await statOrNull(fullPath);
+    if (stats && !stats.isFile()) {
+        return res.status(405).send("not a file");
+    }
+
+    const ifMatch = req.get("If-Match");
+    if (ifMatch !== undefined) {
+        const current = stats ? fileEtag(stats) : null;
+        const matched = ifMatch.trim() === "*"
+            ? !!current
+            : !!current && ifMatch.split(",").some(tag => tag.trim() === current);
+
+        if (!matched) {
+            if (current) {
+                res.set("ETag", current);
+            }
+            return res.status(412).send(`'${req.path}' has changed since it was read`);
+        }
+    }
+
+    // WebDAV answers 409 for a missing parent collection, which collides with the 409 a client
+    // reads as "could not reconcile". Create the folder instead.
+    await fs.promises.mkdir(path.dirname(fullPath), { recursive: true });
+
+    // write beside the target and rename over it, so a failed upload can't truncate the file
+    const tempPath = `${fullPath}.${process.pid}.tmp`;
+    try {
+        await pipeline(req, fs.createWriteStream(tempPath));
+        await fs.promises.rename(tempPath, fullPath);
+    }
+    catch (error) {
+        await fs.promises.rm(tempPath, { force: true });
+        throw error;
+    }
+
+    res.set("ETag", fileEtag(await fs.promises.stat(fullPath)));
+    res.status(stats ? 204 : 201).end();
+}
+
+app.use(handlePut);
+
+// Reads. Supplies the entity-tag a write quotes back, and brings range requests and `304`
+// handling with it. Directories fall through to WebDAV, so listings still work.
+app.use(express.static(fileDir, {
+    etag: false,
+    index: false,
+    redirect: false,
+    setHeaders: (res, filePath, stats) => res.setHeader("ETag", fileEtag(stats)),
+}));
+
 // WebDAV file server
 const webDAVServer = new webdav.WebDAVServer();
 webDAVServer.setFileSystem("/", new webdav.PhysicalFileSystem(fileDir), success => {
@@ -93,15 +211,7 @@ webDAVServer.setFileSystem("/", new webdav.PhysicalFileSystem(fileDir), success 
 
         const validator = function(req, res, next) {
 
-            const tempPath = decodeURIComponent(req.url).replace(/[\\/]+/g, '/');
-            if (tempPath.indexOf('\0') !== -1) {
-                return res.sendStatus(400);
-            }
-              
-            const rootDirectory = `${fileDir}`;
-              
-            const fullPath = path.join(rootDirectory, tempPath);
-            if (fullPath.indexOf(rootDirectory) !== 0) {
+            if (!resolveFilePath(req.path)) {
                 return res.sendStatus(400);
             }
 


### PR DESCRIPTION
When saving, voyager currently only checks for success/failure. That's sometimes all you get from the server and that's fine. But I'm trying to improve the cases where the server is giving more information about what is happening and we should be able to communicate that to users. Namely:

|Code| Name | Meaning |
|-------|-----------|---------------|
|205  | Reset Content | server-side copy has diverged, user should run `reloadDocument()`|
|412 | Precondition Failed | This would overwrite changes made by someone else |

A `205` wouldn't ever happen unless the server has some kind of server-side validation or merge mechanism, but I thought this PR was a good opportunity to have it (Our server is answering `205` on successful merges) and it won't hurt the other implementations.


## Content

First two commits are preliminary work:
1. Add IDs that were omitted from the document and re-generated on each load. Prevents reliable merge heuristics server-side (no direct use within this PR)
2. Allow localized string to have a "dictionary key" that is different from the "default text", improving readability and robustness for long help strings. Also add a simple interpolation feature (eg: `{text: "saved {0}", key: "saved.file", args:["scene.svx.json"]}`)

Commit **3** (d49293b7752301675a536b60f084bc68bd25c665) is the actual implementation.

I've made an additional commit to demonstrate the feature for `412` status codes using the dev server. I felt it would be nice to have an easy way to test the feature, but it adds ~100 lines to the demo code so I'm not sure we should keep it past the testing phase?

## The Implementation

Make the asset manager save assets `Etag` on `GET` and stamp it to `If-Match` on `PUT`.

Show dialog boxes to let the user know when he hits one of those status codes and what he can do about it.