### PR TITLE
balance every loadingManager itemStart with an itemEnd

### DIFF
--- a/source/client/io/AudioReader.ts
+++ b/source/client/io/AudioReader.ts
@@ -36,15 +36,17 @@ export default class AudioReader
             request.responseType = 'arraybuffer';
             request.onload = () => {
                 if (request.status >= 200 && request.status < 300) {
-                    this.loadingManager.itemEnd(url)
+                    this.loadingManager.itemEnd(url);
                     resolve(request.response); 
                 } else {
                     this.loadingManager.itemError(url);
+                    this.loadingManager.itemEnd(url);
                     reject(Error(request.statusText));
                 }
             };
             request.onerror = () => {
                 this.loadingManager.itemError(url);
+                this.loadingManager.itemEnd(url);
                 reject(Error("Possible network error"));
             };
             request.send();

--- a/source/client/io/FileReader.ts
+++ b/source/client/io/FileReader.ts
@@ -35,20 +35,26 @@ export default class FileReader
     {
         this._loadingManager.itemStart(url);
 
-        return fetch(url, {
-            headers: {
-                "Accept": "application/json"
-            }
-        }).then(result => {
+        try {
+            const result = await fetch(url, {
+                headers: {
+                    "Accept": "application/json"
+                }
+            });
+
             if (!result.ok) {
-                this._loadingManager.itemError(url);
-                this._loadingManager.itemEnd(url);
                 throw new Error(`failed to fetch from '${url}', status: ${result.status} ${result.statusText}`);
             }
 
+            return await result.json();
+        }
+        catch (error) {
+            this._loadingManager.itemError(url);
+            throw error;
+        }
+        finally {
             this._loadingManager.itemEnd(url);
-            return result.json();
-        });
+        }
     }
 
     /**

--- a/source/client/io/FontReader.ts
+++ b/source/client/io/FontReader.ts
@@ -77,7 +77,6 @@ export default class FontReader
             }
         }).then(result => {
             if (!result.ok) {
-                this._loadingManager.itemError(url);
                 throw new Error(`failed to load bitmap font descriptor: '${descriptorUrl}', status: ${result.status} ${result.statusText}`);
             }
 
@@ -94,15 +93,21 @@ export default class FontReader
             });
         });
 
-        return Promise.all([ loadDescriptor, loadBitmap ])
-            .then(result => {
-                const font: IBitmapFont = {
-                    descriptor: result[0] as object,
-                    texture: result[1] as Texture,
-                };
-                this._cache[url] = font;  // TODO: Revisit caching - this doesn't do much for us
-                this._loadingManager.itemEnd(url);
-                return font;
-            });
+        try {
+            const result = await Promise.all([ loadDescriptor, loadBitmap ]);
+            const font: IBitmapFont = {
+                descriptor: result[0] as object,
+                texture: result[1] as Texture,
+            };
+            this._cache[url] = font;  // TODO: Revisit caching - this doesn't do much for us
+            return font;
+        }
+        catch (error) {
+            this._loadingManager.itemError(url);
+            throw error;
+        }
+        finally {
+            this._loadingManager.itemEnd(url);
+        }
     }
 }


### PR DESCRIPTION
`LoadingManager.itemEnd()` should be called after `loadingManager.itemError` if the error is fatal (ie: we have no intention of retrying, fetch a fallback, etc...).

To reproduce the issue, create an audio element pointing at a file that does not exist. Save the scene and reload: The `<sv-spinner>` spins forever. 

The missing audio file isn't visually reported either, but this is another issue.

It was already correct in `ModelReader`, which represent most of the expected failures so we didn't see the unbalance too often (`ModelReader.ts:L152-155`):

```typescript
        .catch((e)=> {
            this.loadingManager.itemError(url);
            throw e;
        }).finally(()=> this.loadingManager.itemEnd( url ));
```

I also fixed the FontReader even if it isn't used anywhere at the moment.
